### PR TITLE
Switch init API to new fingerprint-based endpoint

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -14,7 +14,7 @@ export const BOOT_TASKS_ORDER: BootTask[] = [
 
 // API URLs
 export const API_URLS = {
-  init: "https://d5ddiovnmsbs5p6merq9.8wihnuyr.apigw.yandexcloud.net/init",
+  init: "https://functions.yandexcloud.net/d4eft5881ootoasr4lcn",
   mainmenu:
     "https://d5ddiovnmsbs5p6merq9.8wihnuyr.apigw.yandexcloud.net/mainmenu",
   notifications:

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -11,7 +11,7 @@ import {
   ImpactResponse,
 } from "../types";
 import { API_URLS } from "../constants";
-import { withRetry, invalidateImageCache } from "../utils";
+import { withRetry, invalidateImageCache, getFingerprint } from "../utils";
 
 export class ApiService {
   private onError?: (error: string) => void;
@@ -23,11 +23,9 @@ export class ApiService {
   async init(): Promise<InitResponse> {
     return withRetry(
       async () => {
+        const fingerprint = getFingerprint();
         const response = await axios.post<InitResponse>(API_URLS.init, {
-          yandexUserId: "ajeksdnx-somerandomid-29112024",
-          yandexUserName: "Иван Петров",
-          yandexUserPhotoURL:
-            "https://avatars.yandex.net/get-yapic/12345/some-image-id/islands-200",
+          fingerprint,
         });
         return response.data;
       },

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,21 @@ export const invalidateImageCache = (url: string): string => {
   return `${url}${separator}t=${timestamp}`;
 };
 
+// Простая генерация отпечатка браузера
+export const getFingerprint = (): string => {
+  const components = [
+    navigator.userAgent,
+    navigator.language,
+    String(screen.colorDepth),
+    String(screen.width),
+    String(screen.height),
+    String(screen.availWidth),
+    String(screen.availHeight),
+    String(new Date().getTimezoneOffset()),
+  ];
+  return btoa(components.join("|"));
+};
+
 // Форматирование таймера
 export const formatTimer = (timeInSeconds: number): string => {
   const hours = Math.floor(timeInSeconds / 3600);


### PR DESCRIPTION
## Summary
- use new Yandex Cloud init endpoint
- send browser fingerprint when initializing

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a640736d0c832a94034f9c19a55d28