### PR TITLE
Fix raising block layout to restore frame display

### DIFF
--- a/src/components/ImpactsGrid.tsx
+++ b/src/components/ImpactsGrid.tsx
@@ -24,7 +24,7 @@ const ImpactsGrid: React.FC<ImpactsGridProps> = ({
   onImpactClick,
 }) => {
   return (
-    <div className="w-full md:w-1/2 mt-4 md:mt-0 grid grid-cols-2 md:grid-cols-4 gap-1 bg-purple-200">
+    <div className="w-full md:w-2/5 mt-4 md:mt-0 grid grid-cols-2 md:grid-cols-5 gap-1 bg-purple-200">
       {impacts.map((impact) => (
         <div
           key={impact.id}

--- a/src/components/RaisingSection.tsx
+++ b/src/components/RaisingSection.tsx
@@ -134,7 +134,7 @@ const RaisingSection: React.FC<RaisingSectionProps> = ({
 
       <div className="mt-4 flex flex-col md:flex-row md:space-x-1">
         {/* Комната монстра */}
-        <div className="w-full md:w-1/2 border border-gray-300 bg-orange-100">
+        <div className="w-full md:w-2/5 border border-gray-300 bg-orange-100">
           {roomImage && monsterImage && (
             <div
               className="relative"
@@ -193,7 +193,7 @@ const RaisingSection: React.FC<RaisingSectionProps> = ({
         </div>
 
         {/* Набор доступных воспитательных взаимодействий с монстром */}
-        <div className="w-full md:w-1/2 mt-4 md:mt-0 grid grid-cols-2 md:grid-cols-4 gap-1 bg-purple-200">
+        <div className="w-full md:w-2/5 mt-4 md:mt-0 grid grid-cols-2 md:grid-cols-5 gap-1 bg-purple-200">
           {impacts.map((impact) => (
             <div
               key={impact.id}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -540,7 +540,7 @@ const App: React.FC = () => {
                 monsterImage={monsterImage}
                 roomItems={roomItems}
                 isLoading={isMonsterLoading}
-                className="w-full md:w-1/2 border border-gray-300 bg-orange-100"
+                className="w-full md:w-2/5 border border-gray-300 bg-orange-100"
               />
 
               {/* Характеристики монстра перемещены ниже комнаты, но вне CompositeRoomRenderer */}
@@ -566,7 +566,7 @@ const App: React.FC = () => {
               </div>
 
               {/* Набор доступных воспитательных взаимодействий с монстром */}
-              <div className="w-full md:w-1/2 mt-4 md:mt-0 grid grid-cols-2 md:grid-cols-4 gap-1 bg-purple-200">
+              <div className="w-full md:w-2/5 mt-4 md:mt-0 grid grid-cols-2 md:grid-cols-5 gap-1 bg-purple-200">
                 {impacts.map((impact) => {
                   // Получаем иконку выносливости для отображения минимальных требований
                   const enduranceIcon =
@@ -625,7 +625,7 @@ const App: React.FC = () => {
               </div>
 
               {/* Характеристики монстра для десктопа */}
-              <div className="hidden md:block mt-4 space-y-2 p-2 md:ml-1 md:w-1/4">
+              <div className="hidden md:block mt-4 space-y-2 p-2 md:ml-1 md:w-1/5">
                 {characteristics
                   .slice()
                   .sort((a, b) => b.value - a.value)


### PR DESCRIPTION
## Summary
- tweak widths for raising section components so room, grid and stats render side by side
- show five columns of interaction frames for consistent sizing
- expose narrower desktop characteristics panel

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a64902f980832a929d33152c79cebb