### PR TITLE
feat: enhance monster switcher visuals

### DIFF
--- a/src/components/MonsterSwitcher.tsx
+++ b/src/components/MonsterSwitcher.tsx
@@ -29,11 +29,11 @@ const MonsterSwitcher: React.FC<MonsterSwitcherProps> = ({
           <img
             src={monster.face}
             alt={monster.name}
-            className="w-full h-[129px] object-cover border border-gray-300"
+            className="w-full h-[129px] object-cover border border-gray-400"
           />
           <div
-            className="flex-1 flex items-center justify-center text-center font-handwritten leading-tight"
-            style={{ fontSize: "clamp(0.8rem, 2vw, 1.2rem)" }}
+            className="flex-1 flex items-center justify-center text-center font-handwritten leading-none"
+            style={{ fontSize: "clamp(0.8rem, 5vw, 4rem)" }}
           >
             {monster.name}
           </div>


### PR DESCRIPTION
## Summary
- add border around monster images in switcher
- use flex and responsive font sizing to fill name area

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a650cae454832abd1637096b99c31d