### PR TITLE
feat: add account menu badges

### DIFF
--- a/src/Account.tsx
+++ b/src/Account.tsx
@@ -1,14 +1,45 @@
 import React from "react";
 
+/**
+ * Простое меню аккаунта.
+ * Содержит большую кнопку для перехода в профиль пользователя
+ * и бейдж с вариантами авторизации через популярные сервисы.
+ * Пока реализована только визуальная часть.
+ */
 const Account: React.FC = () => {
   return (
-    <div className="p-8 min-h-[50vh] flex items-center justify-center">
-      <div className="rounded-2xl shadow-xl border border-rose-300 bg-rose-100 px-8 py-10 text-center">
-        <div className="text-3xl font-bold text-rose-800 mb-2">🚧</div>
-        <div className="text-2xl font-semibold text-rose-800">Раздел на ремонте</div>
+    <div className="p-8 flex justify-center">
+      <div className="w-full max-w-sm space-y-4">
+        <button className="w-full bg-purple-600 text-white py-4 rounded-xl text-xl font-semibold active:scale-95">
+          Профиль пользователя
+        </button>
+
+        <div className="border border-gray-300 rounded-xl p-4 bg-white shadow flex flex-col items-center space-y-3">
+          <span className="text-gray-700 font-medium">
+            Авторизоваться через
+          </span>
+          <div className="flex space-x-4">
+            <img
+              src="https://img.icons8.com/color/48/google-logo.png"
+              alt="Google"
+              className="w-10 h-10"
+            />
+            <img
+              src="https://img.icons8.com/color/48/yandex.png"
+              alt="Yandex"
+              className="w-10 h-10"
+            />
+            <img
+              src="https://img.icons8.com/color/48/vk-com.png"
+              alt="VK"
+              className="w-10 h-10"
+            />
+          </div>
+        </div>
       </div>
     </div>
   );
 };
 
 export default Account;
+

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -40,6 +40,6 @@ export const MENU_SEQUENCES = {
   RAISING: 1,
   ARENA: 2,
   SHOP: 3,
-  INVENTORY: 4,
-  ACCOUNT: 5,
+  ACCOUNT: 4,
+  INVENTORY: 5,
 } as const;


### PR DESCRIPTION
## Summary
- show account menu with profile button and auth badges
- align account menu sequence with item order

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d92dffcc832a9fc37b178a7d88e1