### PR TITLE
Fix UTF-8 handling for Google account names

### DIFF
--- a/src/Account.tsx
+++ b/src/Account.tsx
@@ -122,20 +122,24 @@ const Account: React.FC<AccountProps> = ({ userId }) => {
     setGoogleLoading(true);
     
     try {
-      // Декодируем JWT токен для получения информации о пользователе
+      // Декодируем JWT токен с учетом Unicode-символов
       const credential = credentialResponse.credential;
-      const payload = JSON.parse(atob(credential.split('.')[1]));
-      
-      // Правильно кодируем имя пользователя в UTF-8
-      const userName = payload.name || "";
-      const encodedUserName = encodeURIComponent(userName);
-      
+      const base64Url = credential.split('.')[1];
+      const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+      const jsonPayload = decodeURIComponent(
+        atob(base64)
+          .split('')
+          .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+          .join('')
+      );
+      const payload = JSON.parse(jsonPayload);
+
       const googleUserData = {
         userId: userId,
-        newserviceid: payload.sub, // Google ID пользователя
-        newservicename: decodeURIComponent(encodedUserName), // Имя пользователя с правильной кодировкой
-        newserviceimage: payload.picture, // URL аватара
-        service: "google"
+        newserviceid: payload.sub,
+        newservicename: payload.name || "",
+        newserviceimage: payload.picture,
+        service: "google",
       };
 
       console.log("Отправляем данные в Yandex функцию:", googleUserData);


### PR DESCRIPTION
## Summary
- decode Google OAuth JWT with Unicode-safe base64 handling
- send decoded username and avatar to Yandex function using UTF-8

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a87e247c6c832abfb9db72a63891e8