### PR TITLE
fix: refresh monster list when entering raising

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -407,6 +407,20 @@ const App: React.FC = () => {
     }
   };
 
+  // Загрузка списка монстров для переключателя
+  const loadMonsters = async () => {
+    if (monstersId.length === 0) return;
+    try {
+      const monstersRes = await apiService.getMonsters(monstersId);
+      const sorted = (monstersRes.monsters || []).sort(
+        (a, b) => a.sequence - b.sequence
+      );
+      setMonsters(sorted);
+    } catch {
+      // ошибка уже показана
+    }
+  };
+
   // Загрузка данных монстра при смене selectedMonsterId
   useEffect(() => {
     if (booting || !selectedMonsterId) return;
@@ -532,6 +546,7 @@ const App: React.FC = () => {
           loadCharacteristics(),
           loadMonsterRoom(),
           loadImpacts(),
+          loadMonsters(),
         ]);
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- reload monster list when opening the Raising section

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aa16a69258832a98f4c1e0c5f1d32c