### PR TITLE
feat: add arena monster switcher component

### DIFF
--- a/src/Arena.tsx
+++ b/src/Arena.tsx
@@ -1,14 +1,22 @@
 import React from "react";
 import CompetitionEnergy from "./components/CompetitionEnergy";
+import ArenaMonsterSwitcher from "./components/ArenaMonsterSwitcher";
 
 interface ArenaProps {
   userId: number | null;
 }
 
 const Arena: React.FC<ArenaProps> = ({ userId }) => {
+  if (!userId) return null;
+
   return (
-    <div className="p-8 min-h-[50vh] flex flex-col items-center">
-      {userId && <CompetitionEnergy userId={userId} />}
+    <div className="p-8 min-h-[50vh] flex flex-col md:flex-row gap-4 md:items-start md:justify-center">
+      <div className="flex-1">
+        <CompetitionEnergy userId={userId} />
+      </div>
+      <div className="flex-1">
+        <ArenaMonsterSwitcher userId={userId} />
+      </div>
     </div>
   );
 };

--- a/src/components/ArenaMonsterSwitcher.tsx
+++ b/src/components/ArenaMonsterSwitcher.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import { API_URLS } from "../constants";
+import { ArenaMonster, ArenaMonstersResponse } from "../types";
+
+const SPRITE_SCALE = 0.12; // коэффициент уменьшения спрайтов (измените это значение для регулировки размера)
+const SPRITE_GAP = 20; // расстояние между спрайтами по горизонтали
+const SPRITE_BOTTOM = 20; // положение спрайтов относительно низа фона
+const SPRITE_WIDTH = 1280 * SPRITE_SCALE;
+const SPRITE_HEIGHT = 853 * SPRITE_SCALE;
+
+const BG_URL = "https://storage.yandexcloud.net/svm/img/lockerroomcycle.png";
+const BG_WIDTH = 500;
+const BG_HEIGHT = 250;
+
+interface Props {
+  userId: number;
+}
+
+const ArenaMonsterSwitcher: React.FC<Props> = ({ userId }) => {
+  const [monsters, setMonsters] = useState<ArenaMonster[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await axios.post<ArenaMonstersResponse>(
+          API_URLS.arenamonsters,
+          { userId }
+        );
+        const data = res.data.arenamonsters || [];
+        setMonsters(data);
+        if (data.length > 0) {
+          const minId = Math.min(...data.map((m) => m.arenamonsterid));
+          setSelectedId(minId);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    load();
+  }, [userId]);
+
+  const bgCount = Math.ceil(monsters.length / 3);
+  const containerWidth = bgCount * BG_WIDTH;
+
+  return (
+    <div className="w-full overflow-x-auto rounded-xl border-2 border-green-300 bg-green-50 shadow-md p-4">
+      <div
+        className="relative"
+        style={{
+          width: containerWidth,
+          height: BG_HEIGHT,
+          backgroundImage: `url(${BG_URL})`,
+          backgroundRepeat: "repeat-x",
+        }}
+      >
+        {monsters.map((m, index) => {
+          const left = SPRITE_GAP + index * (SPRITE_WIDTH + SPRITE_GAP);
+          const isSelected = selectedId === m.arenamonsterid;
+          return (
+            <div
+              key={m.arenamonsterid}
+              style={{
+                position: "absolute",
+                left,
+                bottom: SPRITE_BOTTOM,
+                width: SPRITE_WIDTH,
+                textAlign: "center",
+                cursor: "pointer",
+              }}
+              onClick={() => setSelectedId(m.arenamonsterid)}
+            >
+              <div className="font-handwritten" style={{ marginBottom: 4 }}>
+                {m.arenamonstername}
+              </div>
+              <img
+                src={m.arenamonsterimage}
+                alt={m.arenamonstername}
+                style={{
+                  width: SPRITE_WIDTH,
+                  height: SPRITE_HEIGHT,
+                  opacity: isSelected ? 1 : 0.5,
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ArenaMonsterSwitcher;

--- a/src/components/CompetitionEnergy.tsx
+++ b/src/components/CompetitionEnergy.tsx
@@ -54,8 +54,8 @@ const CompetitionEnergy: React.FC<Props> = ({ userId }) => {
   if (energy == null) return null;
 
   return (
-    <div className="w-full flex justify-center mb-6">
-      <div className="flex flex-col items-center rounded-xl border-2 border-blue-300 bg-blue-50 shadow-md p-4 w-full md:w-auto">
+    <div className="w-full flex justify-center mb-6 md:mb-0">
+      <div className="flex flex-col items-center md:justify-between rounded-xl border-2 border-blue-300 bg-blue-50 shadow-md p-4 w-full md:w-auto md:h-[282px]">
         <div className="flex items-center gap-3">
           <img
             src={IMAGES.competitionEnergy}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -23,6 +23,7 @@ export const API_URLS = {
     "https://d5ddiovnmsbs5p6merq9.8wihnuyr.apigw.yandexcloud.net/monsters",
   teachenergy: "https://functions.yandexcloud.net/d4ek0gg34e57hosr45u8",
   competitionenergy: "https://functions.yandexcloud.net/d4e83k58k32gf9ibt1jt",
+  arenamonsters: "https://functions.yandexcloud.net/d4es67buap1fl8ad3sp8",
   characteristics: "https://functions.yandexcloud.net/d4eja3aglipp5f8hfb73",
   monsterroom: "https://functions.yandexcloud.net/d4eqemr3g0g9i1kbt5u0",
   impacts: "https://functions.yandexcloud.net/d4en3p6tiu5kcoe261mj",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,16 @@ export interface CompetitionEnergyResponse {
   nextfreereplenishment: string;
 }
 
+export interface ArenaMonster {
+  arenamonsterid: number;
+  arenamonstername: string;
+  arenamonsterimage: string;
+}
+
+export interface ArenaMonstersResponse {
+  arenamonsters: ArenaMonster[];
+}
+
 export interface MonsterCharacteristic {
   id: number;
   value: number;


### PR DESCRIPTION
## Summary
- add border styling and instructions for ArenaMonsterSwitcher
- place ArenaMonsterSwitcher to the right of CompetitionEnergy with spacing
- match CompetitionEnergy height to monster switcher on wide screens
- center Arena block components on screen
- keep CompetitionEnergy visible on small screens by stacking the monster switcher below

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa48fcd834832a931cb58eac1088d2