### PR TITLE
Add competitions component to Arena

### DIFF
--- a/src/Arena.tsx
+++ b/src/Arena.tsx
@@ -1,22 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
 import CompetitionEnergy from "./components/CompetitionEnergy";
 import ArenaMonsterSwitcher from "./components/ArenaMonsterSwitcher";
+import Competitions from "./components/Competitions";
 
 interface ArenaProps {
   userId: number | null;
 }
 
 const Arena: React.FC<ArenaProps> = ({ userId }) => {
+  const [selectedMonsterId, setSelectedMonsterId] = useState<number | null>(null);
   if (!userId) return null;
 
   return (
-    <div className="p-8 min-h-[50vh] flex flex-col md:flex-row gap-4 md:items-start md:justify-center">
-      <div className="flex-1">
-        <CompetitionEnergy userId={userId} />
+    <div className="p-8 min-h-[50vh] flex flex-col gap-4 md:items-start md:justify-center">
+      <div className="flex flex-col md:flex-row gap-4">
+        <div className="flex-1">
+          <CompetitionEnergy userId={userId} />
+        </div>
+        <div className="flex-1">
+          <ArenaMonsterSwitcher userId={userId} onSelect={setSelectedMonsterId} />
+        </div>
       </div>
       <div className="flex-1">
-
-        <ArenaMonsterSwitcher userId={userId} />
+        <Competitions monsterId={selectedMonsterId} />
       </div>
     </div>
   );

--- a/src/components/ArenaMonsterSwitcher.tsx
+++ b/src/components/ArenaMonsterSwitcher.tsx
@@ -15,9 +15,10 @@ const BG_HEIGHT = 250;
 
 interface Props {
   userId: number;
+  onSelect?: (id: number) => void;
 }
 
-const ArenaMonsterSwitcher: React.FC<Props> = ({ userId }) => {
+const ArenaMonsterSwitcher: React.FC<Props> = ({ userId, onSelect }) => {
   const [monsters, setMonsters] = useState<ArenaMonster[]>([]);
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
@@ -40,6 +41,12 @@ const ArenaMonsterSwitcher: React.FC<Props> = ({ userId }) => {
     };
     load();
   }, [userId]);
+
+  useEffect(() => {
+    if (selectedId !== null) {
+      onSelect?.(selectedId);
+    }
+  }, [selectedId, onSelect]);
 
   const bgCount = Math.ceil(monsters.length / 3);
   const containerWidth = bgCount * BG_WIDTH;

--- a/src/components/Competitions.tsx
+++ b/src/components/Competitions.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import { API_URLS, IMAGES } from "../constants";
+import {
+  MonsterCompetition,
+  MonsterCompetitionsResponse,
+} from "../types";
+
+interface Props {
+  monsterId: number | null;
+}
+
+const Competitions: React.FC<Props> = ({ monsterId }) => {
+  const [competitions, setCompetitions] = useState<MonsterCompetition[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await axios.post<MonsterCompetitionsResponse>(
+          API_URLS.monstercompetitions,
+          { monsterId }
+        );
+        setCompetitions(res.data.monstercompetitions || []);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    if (monsterId) {
+      load();
+    }
+  }, [monsterId]);
+
+  if (!monsterId) return null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {competitions.map((comp) => {
+        const isActive = comp.activity;
+        return (
+          <div
+            key={comp.monstercompetitionid}
+            title={isActive ? undefined : comp.inactivity}
+            className={`rounded-xl border-2 border-green-300 bg-green-50 shadow-md overflow-hidden ${
+              isActive ? "cursor-pointer" : "cursor-not-allowed opacity-50"
+            }`}
+          >
+            <img
+              src={comp.monstercompetitionimage}
+              alt={comp.monstercompetitionname}
+              width={1000}
+              height={500}
+              className="w-full h-auto"
+            />
+            <div className="p-4 flex flex-col gap-2">
+              <div className="flex justify-between">
+                <div className="flex items-center gap-1">
+                  <img
+                    src={IMAGES.competitionEnergy}
+                    alt="energy"
+                    className="h-5 w-auto"
+                  />
+                  <span>{comp.monstercompetitionenergyprice}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <img
+                    src={IMAGES.participants}
+                    alt="participants"
+                    className="h-5 w-auto"
+                  />
+                  <span>{comp.monstercompetitionparticipantsnumber}</span>
+                </div>
+              </div>
+              <div className="text-center text-xl font-bold font-handwritten">
+                {comp.monstercompetitionname}
+              </div>
+              <div className="flex flex-wrap justify-center gap-2">
+                {comp.monstercompetitioncharacteristics.map((c) => (
+                  <div
+                    key={c.monstercompetitioncharacteristicid}
+                    className="flex flex-col items-center"
+                  >
+                    <img
+                      src={c.monstercompetitioncharacteristicimage}
+                      alt={c.monstercompetitioncharacteristicname}
+                      title={c.monstercompetitioncharacteristicname}
+                      className="h-6 w-6"
+                    />
+                    <span className="text-sm">
+                      {c.monstercompetitioncharacteristicamount}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Competitions;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -24,6 +24,7 @@ export const API_URLS = {
   teachenergy: "https://functions.yandexcloud.net/d4ek0gg34e57hosr45u8",
   competitionenergy: "https://functions.yandexcloud.net/d4e83k58k32gf9ibt1jt",
   arenamonsters: "https://functions.yandexcloud.net/d4es67buap1fl8ad3sp8",
+  monstercompetitions: "https://functions.yandexcloud.net/d4eal266kagbsgd7r853",
   characteristics: "https://functions.yandexcloud.net/d4eja3aglipp5f8hfb73",
   monsterroom: "https://functions.yandexcloud.net/d4eqemr3g0g9i1kbt5u0",
   impacts: "https://functions.yandexcloud.net/d4en3p6tiu5kcoe261mj",
@@ -37,6 +38,7 @@ export const IMAGES = {
   energy: "https://storage.yandexcloud.net/svm/img/userteachenergy.png",
   competitionEnergy:
     "https://storage.yandexcloud.net/svm/img/usercompetitionenergy.png",
+  participants: "https://storage.yandexcloud.net/svm/img/participants.png",
 };
 
 // Последовательности меню

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,6 +78,28 @@ export interface MonsterImpactsResponse {
   monsterimpacts: MonsterImpact[];
 }
 
+export interface MonsterCompetitionCharacteristic {
+  monstercompetitioncharacteristicid: string;
+  monstercompetitioncharacteristicimage: string;
+  monstercompetitioncharacteristicname: string;
+  monstercompetitioncharacteristicamount: number;
+}
+
+export interface MonsterCompetition {
+  monstercompetitionid: string;
+  monstercompetitionname: string;
+  monstercompetitionimage: string;
+  monstercompetitionenergyprice: number;
+  monstercompetitionparticipantsnumber: number;
+  activity: boolean;
+  monstercompetitioncharacteristics: MonsterCompetitionCharacteristic[];
+  inactivity?: string;
+}
+
+export interface MonsterCompetitionsResponse {
+  monstercompetitions: MonsterCompetition[];
+}
+
 export interface RoomItem {
   id: number;
   name: string;


### PR DESCRIPTION
## Summary
- add API constants for monster competitions and participants icon
- enable monster selection callbacks and integrate Competitions component
- fetch and display competition badges with energy costs and requirements

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac8881e4d0832a95330c8eeebba2af