### PR TITLE
feat: add horizontal scrolling to arena monster switcher

### DIFF
--- a/src/components/ArenaMonsterSwitcher.tsx
+++ b/src/components/ArenaMonsterSwitcher.tsx
@@ -30,7 +30,6 @@ const ArenaMonsterSwitcher: React.FC<Props> = ({
   );
   const [isInitialized, setIsInitialized] = useState<boolean>(false); // флаг инициализации
   const containerRef = useRef<HTMLDivElement>(null);
-  const [containerWidth, setContainerWidth] = useState<number>(0);
 
   // Используем внешний selectedMonsterId если он передан, иначе внутренний
   const selectedId =
@@ -73,13 +72,8 @@ const ArenaMonsterSwitcher: React.FC<Props> = ({
     load();
   }, [userId]); // убираем propSelectedMonsterId и onMonsterChange из зависимостей
 
-  useEffect(() => {
-    const updateWidth = () =>
-      setContainerWidth(containerRef.current?.clientWidth || 0);
-    updateWidth();
-    window.addEventListener("resize", updateWidth);
-    return () => window.removeEventListener("resize", updateWidth);
-  }, []);
+  // Ограничиваем количество повторений фонового тайла только нужной шириной
+  // и даем возможность прокручивать список, если он шире контейнера
 
   const handleMonsterClick = (monsterId: number) => {
     if (propSelectedMonsterId === undefined) {
@@ -93,9 +87,11 @@ const ArenaMonsterSwitcher: React.FC<Props> = ({
     }
   };
 
-  // Ширина фона зависит от ширины контейнера и числа монстров
-  const contentWidth = monsters.length * (SPRITE_WIDTH + SPRITE_GAP) + SPRITE_GAP;
-  const backgroundWidth = Math.max(containerWidth, contentWidth);
+  // Ширина фона определяется количеством монстров и округляется до ширины тайла
+  const contentWidth =
+    monsters.length * (SPRITE_WIDTH + SPRITE_GAP) + SPRITE_GAP;
+  const backgroundWidth =
+    Math.ceil(contentWidth / BG_TILE_WIDTH) * BG_TILE_WIDTH;
 
   return (
     <div
@@ -103,7 +99,7 @@ const ArenaMonsterSwitcher: React.FC<Props> = ({
       className="w-full max-w-full min-w-0 overflow-x-auto rounded-xl border-2 border-green-300 bg-green-50 shadow-md p-4"
     >
       <div
-        className="relative"
+        className="relative mx-auto"
         style={{
           width: backgroundWidth,
           height: BG_HEIGHT,


### PR DESCRIPTION
## Summary
- add width calculations for arena monster switcher to limit background tiling
- enable horizontal scrolling on wide screens

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ac97ed3690832a8a65e4403727fe48