### PR TITLE
feat: add matchmaking waiting screen for arena competitions

### DIFF
--- a/src/Arena.tsx
+++ b/src/Arena.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import CompetitionEnergy from "./components/CompetitionEnergy";
 import ArenaMonsterSwitcher from "./components/ArenaMonsterSwitcher";
 import Competitions from "./components/Competitions";
+import CurrentCompetition from "./components/CurrentCompetition";
 
 interface ArenaProps {
   userId: number | null;
@@ -12,13 +13,23 @@ const Arena: React.FC<ArenaProps> = ({ userId }) => {
   const [selectedMonsterId, setSelectedMonsterId] = useState<number | null>(
     null
   );
+  const [currentCompetitionId, setCurrentCompetitionId] =
+    useState<number | null>(null);
 
   // Обработчик смены монстра из ArenaMonsterSwitcher
   const handleMonsterChange = (monsterId: number) => {
     setSelectedMonsterId(monsterId);
   };
 
+  const handleCompetitionStart = (id: number) => {
+    setCurrentCompetitionId(id);
+  };
+
   if (!userId) return null;
+
+  if (currentCompetitionId) {
+    return <CurrentCompetition competitionsInstanceId={currentCompetitionId} />;
+  }
 
   return (
     <div className="p-4 md:p-8 space-y-6">
@@ -55,7 +66,11 @@ const Arena: React.FC<ArenaProps> = ({ userId }) => {
           <h2 className="text-2xl md:text-3xl font-bold text-orange-800 mb-6 text-center">
             Состязания
           </h2>
-          <Competitions selectedMonsterId={selectedMonsterId} userId={userId} />
+          <Competitions
+            selectedMonsterId={selectedMonsterId}
+            userId={userId}
+            onCompetitionStart={handleCompetitionStart}
+          />
         </div>
       </div>
     </div>

--- a/src/components/Competitions.tsx
+++ b/src/components/Competitions.tsx
@@ -1,6 +1,7 @@
 // src/components/Competitions.tsx - компонент "Состязания"
 import React, { useState, useEffect } from "react";
 import axios from "axios";
+import WaitingForOpponentsModal from "./WaitingForOpponentsModal";
 
 interface MonsterCompetitionCharacteristic {
   monstercompetitioncharacteristicid: string;
@@ -27,15 +28,20 @@ interface CompetitionsResponse {
 interface CompetitionsProps {
   selectedMonsterId: number | null;
   userId: number | null;
+  onCompetitionStart?: (id: number) => void;
 }
 
 const Competitions: React.FC<CompetitionsProps> = ({
   selectedMonsterId,
   userId,
+  onCompetitionStart,
 }) => {
   const [competitions, setCompetitions] = useState<MonsterCompetition[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>("");
+  const [selectedCompetitionId, setSelectedCompetitionId] = useState<string | null>(
+    null
+  );
 
   // Функция загрузки состязаний
   const loadCompetitions = async (monsterId: number) => {
@@ -67,8 +73,7 @@ const Competitions: React.FC<CompetitionsProps> = ({
   // Обработчик клика по активному состязанию
   const handleCompetitionClick = (competition: MonsterCompetition) => {
     if (competition.activity) {
-      // Здесь можно добавить логику для начала состязания
-      console.log("Начать состязание:", competition.monstercompetitionname);
+      setSelectedCompetitionId(competition.monstercompetitionid);
     }
   };
 
@@ -219,6 +224,18 @@ const Competitions: React.FC<CompetitionsProps> = ({
           </div>
         </div>
       ))}
+      {selectedCompetitionId && selectedMonsterId && (
+        <WaitingForOpponentsModal
+          monsterId={selectedMonsterId}
+          competitionId={selectedCompetitionId}
+          onCompetitionStart={(id) => {
+            setSelectedCompetitionId(null);
+            if (onCompetitionStart) {
+              onCompetitionStart(id);
+            }
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/CurrentCompetition.tsx
+++ b/src/components/CurrentCompetition.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface Props {
+  competitionsInstanceId: number;
+}
+
+const CurrentCompetition: React.FC<Props> = ({ competitionsInstanceId }) => {
+  return (
+    <div className="p-8 text-center">
+      <h2 className="text-2xl font-bold mb-4">Текущее состязание</h2>
+      <p className="text-gray-700">
+        Состязание #{competitionsInstanceId} в разработке
+      </p>
+    </div>
+  );
+};
+
+export default CurrentCompetition;
+

--- a/src/components/WaitingForOpponentsModal.tsx
+++ b/src/components/WaitingForOpponentsModal.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import Spinner from "./Spinner";
+
+interface WaitingProps {
+  monsterId: number;
+  competitionId: string | number;
+  onCompetitionStart: (id: number) => void;
+}
+
+const WS_ENDPOINT = "wss://d5doo0fs9nl1iu1ae464.akta928u.apigw.yandexcloud.net/ws";
+const START_ENDPOINT = "https://functions.yandexcloud.net/d4euroa2kfgg47hna4f0";
+const GIF_URL = "https://storage.yandexcloud.net/svm/img/matchmakingexpectation.gif";
+
+const WaitingForOpponentsModal: React.FC<WaitingProps> = ({
+  monsterId,
+  competitionId,
+  onCompetitionStart,
+}) => {
+  const [timer, setTimer] = useState(120);
+  const [message, setMessage] = useState<string>("");
+  const [stage, setStage] = useState<"waiting" | "starting">("waiting");
+
+  // Countdown timer
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTimer((t) => (t > 0 ? t - 1 : 0));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // WebSocket connection
+  useEffect(() => {
+    const ws = new WebSocket(WS_ENDPOINT);
+    ws.onopen = () => {
+      ws.send(
+        JSON.stringify({
+          monsterId,
+          competitionId,
+        })
+      );
+    };
+    ws.onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data);
+        if (!data.type) return;
+        const payload = data.payload || {};
+        if (payload.text) {
+          setMessage(payload.text);
+        }
+        if (payload.competitionsinstanceid) {
+          const id = payload.competitionsinstanceid as number;
+          setStage("starting");
+          axios
+            .post(START_ENDPOINT, { competitionsinstanceid: id })
+            .then(() => {
+              onCompetitionStart(id);
+            })
+            .catch((err) => console.error("Ошибка старта состязания", err));
+        }
+      } catch (e) {
+        console.error("Ошибка обработки сообщения WebSocket", e);
+      }
+    };
+    return () => {
+      ws.close();
+    };
+  }, [monsterId, competitionId, onCompetitionStart]);
+
+  const minutes = Math.floor(timer / 60)
+    .toString()
+    .padStart(2, "0");
+  const seconds = (timer % 60).toString().padStart(2, "0");
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center z-50 bg-black bg-opacity-50">
+      <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-md text-center space-y-4">
+        {stage === "waiting" ? (
+          <>
+            <h2 className="text-xl font-bold">Ожидание соперников</h2>
+            <img
+              src={GIF_URL}
+              alt="Ожидание"
+              className="mx-auto"
+              width={480}
+              height={270}
+            />
+            <div className="text-gray-700">
+              Примерное время ожидания соперников
+            </div>
+            <div className="text-2xl font-mono">
+              {minutes}:{seconds}
+            </div>
+            {message && (
+              <div className="mt-4 text-gray-800">{message}</div>
+            )}
+          </>
+        ) : (
+          <>
+            <Spinner size="large" />
+            <div className="text-gray-800">Соревнования почти началось</div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WaitingForOpponentsModal;
+

--- a/src/components/WaitingForOpponentsModal.tsx
+++ b/src/components/WaitingForOpponentsModal.tsx
@@ -73,34 +73,42 @@ const WaitingForOpponentsModal: React.FC<WaitingProps> = ({
   const seconds = (timer % 60).toString().padStart(2, "0");
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center z-50 bg-black bg-opacity-50">
-      <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-md text-center space-y-4">
-        {stage === "waiting" ? (
-          <>
-            <h2 className="text-xl font-bold">Ожидание соперников</h2>
-            <img
-              src={GIF_URL}
-              alt="Ожидание"
-              className="mx-auto"
-              width={480}
-              height={270}
-            />
-            <div className="text-gray-700">
-              Примерное время ожидания соперников
-            </div>
-            <div className="text-2xl font-mono">
-              {minutes}:{seconds}
-            </div>
-            {message && (
-              <div className="mt-4 text-gray-800">{message}</div>
-            )}
-          </>
-        ) : (
-          <>
-            <Spinner size="large" />
-            <div className="text-gray-800">Соревнования почти началось</div>
-          </>
-        )}
+    <div className="fixed inset-0 flex items-center justify-center z-[120] bg-black/60">
+      <div className="bg-gradient-to-br from-purple-50 to-orange-50 p-[2px] rounded-2xl shadow-2xl w-full max-w-md">
+        <div className="bg-white rounded-2xl p-6 text-center space-y-4">
+          {stage === "waiting" ? (
+            <>
+              <h2 className="text-2xl font-bold text-purple-700">
+                Ожидание соперников
+              </h2>
+              <img
+                src={GIF_URL}
+                alt="Ожидание"
+                className="mx-auto rounded-lg shadow-md"
+                width={480}
+                height={270}
+              />
+              <div className="text-gray-700">
+                Примерное время ожидания соперников
+              </div>
+              <div className="text-3xl font-mono font-semibold text-purple-700 tracking-widest">
+                {minutes}:{seconds}
+              </div>
+              {message && (
+                <div className="px-4 py-2 bg-purple-100 text-purple-800 rounded-lg shadow-inner">
+                  {message}
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              <Spinner size="large" />
+              <div className="text-lg font-medium text-purple-800">
+                Соревнование почти началось
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add waiting modal that opens websocket, shows timer, handles start messages
- integrate competitions screen to launch waiting modal and notify arena of start
- show placeholder current competition screen once matchmaking completes

## Testing
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68baf43c79a4832ab4a559ff4ecd539e