### PR TITLE
feat: retry start endpoint on timeout

### DIFF
--- a/src/components/WaitingForOpponentsModal.tsx
+++ b/src/components/WaitingForOpponentsModal.tsx
@@ -40,6 +40,25 @@ const WaitingForOpponentsModal: React.FC<WaitingProps> = ({
         })
       );
     };
+    const startCompetition = (id: number) => {
+      axios
+        .post(
+          START_ENDPOINT,
+          { competitionsinstanceid: id },
+          { timeout: 6000 }
+        )
+        .then(() => {
+          onCompetitionStart(id);
+        })
+        .catch((err: any) => {
+          if (err.code === "ECONNABORTED") {
+            startCompetition(id);
+          } else {
+            console.error("Ошибка старта состязания", err);
+          }
+        });
+    };
+
     ws.onmessage = (ev) => {
       try {
         const data = JSON.parse(ev.data);
@@ -51,12 +70,7 @@ const WaitingForOpponentsModal: React.FC<WaitingProps> = ({
         if (payload.competitionsinstanceid) {
           const id = payload.competitionsinstanceid as number;
           setStage("starting");
-          axios
-            .post(START_ENDPOINT, { competitionsinstanceid: id })
-            .then(() => {
-              onCompetitionStart(id);
-            })
-            .catch((err) => console.error("Ошибка старта состязания", err));
+          startCompetition(id);
         }
       } catch (e) {
         console.error("Ошибка обработки сообщения WebSocket", e);


### PR DESCRIPTION
## Summary
- retry start endpoint after 6s timeout in WaitingForOpponentsModal

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bb57ca3dc8832a9d28eb239f8a9a40