### PR TITLE
Retry shop fetch on slow response

### DIFF
--- a/src/Shop.tsx
+++ b/src/Shop.tsx
@@ -114,7 +114,8 @@ const Shop: React.FC<Props> = ({ userId }) => {
           () =>
             axios.post<ShopResponse>(
               "https://functions.yandexcloud.net/d4eq0b2po3vrtvgqbori",
-              { userId }
+              { userId },
+              { timeout: 3000 }
             ),
           (r) => Array.isArray((r as any)?.data?.inventoryitems),
           "Ошибка при загрузке магазина"


### PR DESCRIPTION
## Summary
- add 3-second timeout to shop inventory request so retries trigger if the service is unresponsive

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bc7ed75020832aa836b069f2bbd53c