### PR TITLE
Add global retry for stalled network requests

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import "./setupRetries";
 import React, { useState, useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";

--- a/src/setupRetries.ts
+++ b/src/setupRetries.ts
@@ -1,0 +1,55 @@
+import axios, { AxiosError, AxiosRequestConfig } from "axios";
+
+const EXCLUDE_URL = "https://functions.yandexcloud.net/d4euroa2kfgg47hna4f0";
+
+axios.interceptors.request.use((config: AxiosRequestConfig) => {
+  if (config.url !== EXCLUDE_URL && !config.timeout) {
+    config.timeout = 5000;
+  }
+  return config;
+});
+
+axios.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const config = error.config;
+    if (
+      error.code === "ECONNABORTED" &&
+      config &&
+      config.url !== EXCLUDE_URL
+    ) {
+      return axios(config);
+    }
+    return Promise.reject(error);
+  }
+);
+
+if (typeof window !== "undefined" && window.fetch) {
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = (input: RequestInfo, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url === EXCLUDE_URL) {
+      return originalFetch(input, init);
+    }
+    const attempt = (): Promise<Response> => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000);
+      const finalInit = { ...(init || {}), signal: controller.signal };
+      return originalFetch(input, finalInit)
+        .then((res) => {
+          clearTimeout(timeoutId);
+          return res;
+        })
+        .catch((err) => {
+          clearTimeout(timeoutId);
+          if (err.name === "AbortError") {
+            return attempt();
+          }
+          throw err;
+        });
+    };
+    return attempt();
+  };
+}
+
+export {}; // ensure this file is treated as a module


### PR DESCRIPTION
## Summary
- retry axios and fetch calls indefinitely after 5s timeout unless targeting the Yandex function endpoint
- initialize retry logic early in app startup

## Testing
- `CI=true npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbddb9264832a98efbbee08efc3ab