### PR TITLE
feat: enable google fedcm prompt

### DIFF
--- a/src/Account.tsx
+++ b/src/Account.tsx
@@ -109,6 +109,9 @@ const Account: React.FC<AccountProps> = ({ userId }) => {
         auto_select: false,
         cancel_on_tap_outside: true,
         context: "use",
+        // Enable FedCM to ensure the Google prompt is displayed even when
+        // third-party cookies are blocked by the browser
+        use_fedcm_for_prompt: true,
       });
       initialized.current = true;
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure Google auth prompt uses FedCM when third-party cookies are blocked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd6d44c488832aa70d799a171f46fb