### PR TITLE
fix: support google auth with blocked cookies

### DIFF
--- a/src/Account.tsx
+++ b/src/Account.tsx
@@ -109,6 +109,11 @@ const Account: React.FC<AccountProps> = ({ userId }) => {
         auto_select: false,
         cancel_on_tap_outside: true,
         context: "use",
+        // Ensure the Google prompt can appear even when third-party cookies
+        // are blocked by the browser by enabling both the older ITP fallback
+        // flow and the newer FedCM mechanism
+        itp_support: true,
+        use_fedcm_for_prompt: true,
       });
       initialized.current = true;
     } catch (error) {


### PR DESCRIPTION
## Summary
- enable ITP fallback and FedCM so Google auth prompt still appears when third-party cookies are blocked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd6d44c488832aa70d799a171f46fb