### PR TITLE
fix: support google auth with blocked cookies

### DIFF
--- a/src/Account.tsx
+++ b/src/Account.tsx
@@ -109,6 +109,11 @@ const Account: React.FC<AccountProps> = ({ userId }) => {
         auto_select: false,
         cancel_on_tap_outside: true,
         context: "use",
+        // Ensure the Google prompt can appear even when third-party cookies
+        // are blocked by the browser by enabling both the older ITP fallback
+        // flow and the newer FedCM mechanism
+        itp_support: true,
+        use_fedcm_for_prompt: true,
       });
       initialized.current = true;
     } catch (error) {
@@ -185,6 +190,33 @@ const Account: React.FC<AccountProps> = ({ userId }) => {
     setGoogleMode(null);
   };
 
+  // Фолбэк на OAuth2 попап, если стандартный prompt не отображается
+  const startGoogleOAuthFallback = () => {
+    if (
+      !window.google ||
+      !window.google.accounts ||
+      !window.google.accounts.oauth2
+    ) {
+      console.error("Google OAuth2 недоступен");
+      handleGoogleError();
+      return;
+    }
+
+    const tokenClient = window.google.accounts.oauth2.initTokenClient({
+      client_id: GOOGLE_CLIENT_ID,
+      scope: "openid profile email",
+      callback: (tokenResponse: any) => {
+        if (tokenResponse && tokenResponse.id_token) {
+          handleGoogleCallback({ credential: tokenResponse.id_token });
+        } else {
+          handleGoogleError();
+        }
+      },
+    });
+
+    tokenClient.requestAccessToken({ prompt: "consent" });
+  };
+
   // Обработчик нажатия на кнопку "Подключить Google"
   const handleConnectGoogle = () => {
     if (!window.google || !window.google.accounts || !initialized.current) {
@@ -199,8 +231,7 @@ const Account: React.FC<AccountProps> = ({ userId }) => {
     window.google.accounts.id.prompt((notification: any) => {
       if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
         console.warn("Google prompt skipped or not displayed");
-        setGoogleLoading(false);
-        setGoogleMode(null);
+        startGoogleOAuthFallback();
       }
     });
   };
@@ -219,8 +250,7 @@ const Account: React.FC<AccountProps> = ({ userId }) => {
     window.google.accounts.id.prompt((notification: any) => {
       if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
         console.warn("Google prompt skipped or not displayed");
-        setGoogleLoading(false);
-        setGoogleMode(null);
+        startGoogleOAuthFallback();
       }
     });
   };


### PR DESCRIPTION
## Summary
- enable ITP fallback and FedCM so Google auth prompt still appears when third-party cookies are blocked
- fall back to OAuth pop-up when the Google prompt can't be displayed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd6d44c488832aa70d799a171f46fb