### PR TITLE
Fix impact interactions by including user ID

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -218,7 +218,8 @@ const App: React.FC = () => {
       if (
         !impact.available ||
         teachEnergy < impact.energyprice ||
-        !selectedMonsterId
+        !selectedMonsterId ||
+        !userId
       )
         return;
 
@@ -226,7 +227,8 @@ const App: React.FC = () => {
       try {
         const response = await apiService.applyImpact(
           selectedMonsterId,
-          impact.id
+          impact.id,
+          userId
         );
         setInteractionData(response);
         setShowRaisingInteraction(true);
@@ -258,6 +260,7 @@ const App: React.FC = () => {
       loadImpacts,
       loadMonsters,
       loadMainMenu,
+      userId,
     ]
   );
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -180,7 +180,8 @@ export class ApiService {
 
   async applyImpact(
     monsterId: number,
-    impactId: number
+    impactId: number,
+    userId: number
   ): Promise<ImpactResponse> {
     // Сбрасываем время последнего запроса энергии при применении воздействия
     this.lastEnergyRequest = 0;
@@ -190,6 +191,7 @@ export class ApiService {
         const response = await axios.post<ImpactResponse>(API_URLS.impact, {
           monsterId,
           impactId,
+          userId,
         });
         return response.data;
       },


### PR DESCRIPTION
## Summary
- include userId when requesting monster impact effect
- ensure impact click handler waits for userId and passes it to API

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be7a849fd0832a842b8b0e6b5e4fc9