### PR TITLE
fix: cancel pending room load on monster switch

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import { SpeedInsights } from "@vercel/speed-insights/react";
@@ -53,6 +53,8 @@ const App: React.FC = () => {
   const [selectedMonsterId, setSelectedMonsterId] = useState<number | null>(
     null
   );
+  const selectedMonsterIdRef = useRef<number | null>(null);
+  const monsterRoomAbortController = useRef<AbortController | null>(null);
   const [teachEnergy, setTeachEnergy] = useState<number>(0);
   const [nextReplenishment, setNextReplenishment] = useState<string>("");
   const [timer, setTimer] = useState<number>(0);
@@ -123,27 +125,58 @@ const App: React.FC = () => {
     [userId, isLoadingEnergy, lastEnergyUpdate, apiService]
   );
 
-  const loadCharacteristics = useCallback(async () => {
-    if (!selectedMonsterId) return;
-    const characteristicsRes = await apiService.getCharacteristics(
-      selectedMonsterId
-    );
-    setCharacteristics(characteristicsRes.monstercharacteristics || []);
-  }, [selectedMonsterId, apiService]);
+  useEffect(() => {
+    selectedMonsterIdRef.current = selectedMonsterId;
+  }, [selectedMonsterId]);
 
-  const loadMonsterRoom = useCallback(async () => {
-    if (!selectedMonsterId) return;
-    const roomRes = await apiService.getMonsterRoom(selectedMonsterId);
-    setMonsterImage(roomRes.monsterimage);
-    setRoomImage(roomRes.roomimage);
-    setRoomItems(roomRes.roomitems || []);
-  }, [selectedMonsterId, apiService]);
+  const loadCharacteristics = useCallback(
+    async (monsterId?: number) => {
+      const id = monsterId ?? selectedMonsterIdRef.current;
+      if (!id) return;
+      const characteristicsRes = await apiService.getCharacteristics(id);
+      if (id !== selectedMonsterIdRef.current) return;
+      setCharacteristics(characteristicsRes.monstercharacteristics || []);
+    },
+    [apiService]
+  );
 
-  const loadImpacts = useCallback(async () => {
-    if (!selectedMonsterId) return;
-    const impactsRes = await apiService.getImpacts(selectedMonsterId);
-    setImpacts(impactsRes.monsterimpacts || []);
-  }, [selectedMonsterId, apiService]);
+  const loadMonsterRoom = useCallback(
+    async (monsterId?: number) => {
+      const id = monsterId ?? selectedMonsterIdRef.current;
+      if (!id) return;
+      // Отменяем предыдущий запрос, если он ещё выполняется
+      monsterRoomAbortController.current?.abort();
+      const controller = new AbortController();
+      monsterRoomAbortController.current = controller;
+      try {
+        const roomRes = await apiService.getMonsterRoom(id, controller.signal);
+        if (
+          controller.signal.aborted ||
+          id !== selectedMonsterIdRef.current
+        )
+          return;
+        setMonsterImage(roomRes.monsterimage);
+        setRoomImage(roomRes.roomimage);
+        setRoomItems(roomRes.roomitems || []);
+      } catch (e) {
+        if (!controller.signal.aborted) {
+          throw e;
+        }
+      }
+    },
+    [apiService]
+  );
+
+  const loadImpacts = useCallback(
+    async (monsterId?: number) => {
+      const id = monsterId ?? selectedMonsterIdRef.current;
+      if (!id) return;
+      const impactsRes = await apiService.getImpacts(id);
+      if (id !== selectedMonsterIdRef.current) return;
+      setImpacts(impactsRes.monsterimpacts || []);
+    },
+    [apiService]
+  );
 
   const loadMonsters = useCallback(async () => {
     if (!monstersId.length) return;
@@ -207,10 +240,27 @@ const App: React.FC = () => {
       setRoomImage("");
       setRoomItems([]);
 
+      setIsMonsterLoading(true);
       setSelectedMonsterId(newMonsterId);
     },
     [selectedMonsterId]
   );
+
+  // --- загрузка данных при изменении монстра ---
+  useEffect(() => {
+    if (!selectedMonsterId) return;
+    const currentId = selectedMonsterId;
+    setIsMonsterLoading(true);
+    Promise.all([
+      loadCharacteristics(currentId),
+      loadMonsterRoom(currentId),
+      loadImpacts(currentId),
+    ])
+      .catch(() => setError("Ошибка при обновлении данных"))
+      .finally(() => {
+        if (currentId === selectedMonsterId) setIsMonsterLoading(false);
+      });
+  }, [selectedMonsterId, loadCharacteristics, loadMonsterRoom, loadImpacts]);
 
   // --- Оптимизированный обработчик клика по воздействию ---
   const handleImpactClick = useCallback(

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -129,17 +129,24 @@ export class ApiService {
       },
       5000,
       "Ошибка при загрузке характеристик монстра",
-      this.onError
+      this.onError,
+      false // Отключаем кеширование, чтобы не блокировать обновление при переключении монстра
     );
   }
 
-  async getMonsterRoom(monsterId: number): Promise<MonsterRoomResponse> {
+  async getMonsterRoom(
+    monsterId: number,
+    signal?: AbortSignal
+  ): Promise<MonsterRoomResponse> {
     return withInfiniteRetryAndTimeout(
       async () => {
         const response = await axios.post<MonsterRoomResponse>(
           API_URLS.monsterroom,
           {
             monsterId,
+          },
+          {
+            signal,
           }
         );
 
@@ -157,7 +164,8 @@ export class ApiService {
       },
       5000,
       "Ошибка при загрузке изображений монстра и комнаты",
-      this.onError
+      this.onError,
+      false // Отключаем кеширование, чтобы можно было прерывать загрузку при переключении монстра
     );
   }
 
@@ -174,7 +182,8 @@ export class ApiService {
       },
       5000,
       "Ошибка при загрузке взаимодействий",
-      this.onError
+      this.onError,
+      false // Отключаем кеширование для корректного переключения монстра
     );
   }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -70,6 +70,13 @@ export async function withInfiniteRetryAndTimeout<T>(
           await new Promise((resolve) => setTimeout(resolve, 300));
           continue;
         }
+        const isAbortError =
+          (e as any)?.code === "ERR_CANCELED" ||
+          (e as any)?.name === "AbortError" ||
+          errorMessage === "canceled";
+        if (isAbortError) {
+          throw e;
+        }
         const text = `${labelForError}: ${errorMessage}`;
         if (onError) {
           onError(text);


### PR DESCRIPTION
## Summary
- track current monster with ref to avoid stale updates when switching
- reload raising room, characteristics, and interactions whenever the selected monster changes
- cancel in-flight room image requests and disable caching for monster data so a new selection loads immediately

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68be834fe868832aa591800fff5b10b4