### PR TITLE
Stabilize competition start callback

### DIFF
--- a/src/components/Competitions.tsx
+++ b/src/components/Competitions.tsx
@@ -1,5 +1,5 @@
 // src/components/Competitions.tsx - компонент "Состязания"
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import axios from "axios";
 import WaitingForOpponentsModal from "./WaitingForOpponentsModal";
 
@@ -90,6 +90,16 @@ const Competitions: React.FC<CompetitionsProps> = ({
       setSelectedCompetitionId(competition.monstercompetitionid);
     }
   };
+
+  const handleCompetitionStart = useCallback(
+    (id: number) => {
+      setSelectedCompetitionId(null);
+      if (onCompetitionStart) {
+        onCompetitionStart(id);
+      }
+    },
+    [onCompetitionStart]
+  );
 
   if (loading) {
     return (
@@ -242,12 +252,7 @@ const Competitions: React.FC<CompetitionsProps> = ({
         <WaitingForOpponentsModal
           monsterId={selectedMonsterId}
           competitionId={selectedCompetitionId}
-          onCompetitionStart={(id) => {
-            setSelectedCompetitionId(null);
-            if (onCompetitionStart) {
-              onCompetitionStart(id);
-            }
-          }}
+          onCompetitionStart={handleCompetitionStart}
         />
       )}
     </div>

--- a/src/components/WaitingForOpponentsModal.tsx
+++ b/src/components/WaitingForOpponentsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import axios from "axios";
 import Spinner from "./Spinner";
 
@@ -20,6 +20,11 @@ const WaitingForOpponentsModal: React.FC<WaitingProps> = ({
   const [timer, setTimer] = useState(120);
   const [message, setMessage] = useState<string>("");
   const [stage, setStage] = useState<"waiting" | "starting">("waiting");
+  const onCompetitionStartRef = useRef(onCompetitionStart);
+
+  useEffect(() => {
+    onCompetitionStartRef.current = onCompetitionStart;
+  }, [onCompetitionStart]);
 
   // Countdown timer
   useEffect(() => {
@@ -48,7 +53,7 @@ const WaitingForOpponentsModal: React.FC<WaitingProps> = ({
           { timeout: 6000 }
         )
         .then(() => {
-          onCompetitionStart(id);
+          onCompetitionStartRef.current(id);
         })
         .catch((err: any) => {
           if (err.code === "ECONNABORTED") {
@@ -79,7 +84,7 @@ const WaitingForOpponentsModal: React.FC<WaitingProps> = ({
     return () => {
       ws.close();
     };
-  }, [monsterId, competitionId, onCompetitionStart]);
+  }, [monsterId, competitionId]);
 
   const minutes = Math.floor(timer / 60)
     .toString()


### PR DESCRIPTION
## Summary
- memoize competition start handler with `useCallback`
- store `onCompetitionStart` in a ref so WebSocket effect only depends on monster and competition IDs

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68bea5b1d374832ab108230eefd1ef61