### PR TITLE
feat: show competition history in arena

### DIFF
--- a/src/Arena.tsx
+++ b/src/Arena.tsx
@@ -4,6 +4,7 @@ import CompetitionEnergy from "./components/CompetitionEnergy";
 import ArenaMonsterSwitcher from "./components/ArenaMonsterSwitcher";
 import Competitions from "./components/Competitions";
 import CurrentCompetition from "./components/CurrentCompetition";
+import CompetitionHistory from "./components/CompetitionHistory";
 
 interface ArenaProps {
   userId: number | null;
@@ -15,6 +16,7 @@ const Arena: React.FC<ArenaProps> = ({ userId }) => {
   );
   const [currentCompetitionId, setCurrentCompetitionId] =
     useState<number | null>(null);
+  const [historyEnabled, setHistoryEnabled] = useState(false);
 
   // Обработчик смены монстра из ArenaMonsterSwitcher
   const handleMonsterChange = (monsterId: number) => {
@@ -24,6 +26,23 @@ const Arena: React.FC<ArenaProps> = ({ userId }) => {
   const handleCompetitionStart = (id: number) => {
     setCurrentCompetitionId(id);
   };
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const controller = new AbortController();
+    fetch(
+      `https://competitionhistoryenable.onrender.com/check?userId=${userId}`,
+      { signal: controller.signal }
+    )
+      .then((res) => res.json())
+      .then((data) => setHistoryEnabled(Boolean(data.competitionhistoryenable)))
+      .catch((err) => {
+        console.error("Ошибка загрузки истории состязаний:", err);
+      });
+
+    return () => controller.abort();
+  }, [userId]);
 
   if (!userId) return null;
 
@@ -59,6 +78,12 @@ const Arena: React.FC<ArenaProps> = ({ userId }) => {
           />
         </div>
       </div>
+
+      {historyEnabled && (
+        <div className="mt-6">
+          <CompetitionHistory />
+        </div>
+      )}
 
       {/* Компонент "Состязания" */}
       <div className="mt-6">

--- a/src/components/CompetitionHistory.tsx
+++ b/src/components/CompetitionHistory.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+const CompetitionHistory: React.FC = () => {
+  return (
+    <div className="bg-gradient-to-br from-orange-50 to-amber-50 rounded-2xl border-2 border-orange-200 shadow-lg p-6">
+      <h2 className="text-2xl md:text-3xl font-bold text-orange-800 text-center">
+        История состязаний
+      </h2>
+    </div>
+  );
+};
+
+export default CompetitionHistory;


### PR DESCRIPTION
## Summary
- fetch competition history toggle on arena load
- render styled competition history banner above competitions

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bf3098acd4832ab382f5c7d9343b08