### PR TITLE
Refresh data after closing raising interaction

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -540,6 +540,21 @@ const App: React.FC = () => {
     ]
   );
 
+  const handleRaisingInteractionClose = useCallback(async () => {
+    try {
+      await Promise.all([
+        loadImpacts(),
+        loadCharacteristics(),
+        loadMonsterRoom(),
+      ]);
+    } catch {
+      setError("Ошибка при обновлении данных");
+    } finally {
+      setShowRaisingInteraction(false);
+      setInteractionData(null);
+    }
+  }, [loadImpacts, loadCharacteristics, loadMonsterRoom]);
+
   // --- UI ---
   return (
     <div className="min-h-screen bg-gradient-to-b from-purple-200 to-orange-200">
@@ -586,10 +601,7 @@ const App: React.FC = () => {
           inventoryItems={interactionData.inventoryitems || []}
           itemEffects={interactionData.itemeffects || []}
           itemBonuses={interactionData.impactitembonuses || []}
-          onClose={() => {
-            setShowRaisingInteraction(false);
-            setInteractionData(null);
-          }}
+          onClose={handleRaisingInteractionClose}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Refresh impacts, characteristics, and monster room images when the raising interaction is closed
- Centralize close logic in `handleRaisingInteractionClose`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c1bc79d848832a8d8e6933e6cfda2c