### PR TITLE
Delay monster switch until room rendering completes

### DIFF
--- a/src/components/CompositeRoomRenderer.tsx
+++ b/src/components/CompositeRoomRenderer.tsx
@@ -19,6 +19,7 @@ interface CompositeRoomRendererProps {
   roomItems: RoomItem[];
   isLoading: boolean;
   className?: string;
+  onReady?: () => void;
 }
 
 const CompositeRoomRenderer: React.FC<CompositeRoomRendererProps> = ({
@@ -27,12 +28,14 @@ const CompositeRoomRenderer: React.FC<CompositeRoomRendererProps> = ({
   roomItems,
   isLoading,
   className = "",
+  onReady,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [isGenerating, setIsGenerating] = useState<boolean>(false);
   const [isReady, setIsReady] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [aspect, setAspect] = useState<string>("4/3");
+  const [monsterLoaded, setMonsterLoaded] = useState<boolean>(false);
 
   // Функция для загрузки изображения с обработкой CORS
   const loadImage = useCallback((src: string): Promise<HTMLImageElement> => {
@@ -159,17 +162,30 @@ const CompositeRoomRenderer: React.FC<CompositeRoomRendererProps> = ({
           ? err.message
           : "Неизвестная ошибка при создании композитного изображения"
       );
+      onReady?.();
     } finally {
       setIsGenerating(false);
     }
-  }, [roomImage, roomItems, loadImage]);
+  }, [roomImage, roomItems, loadImage, onReady]);
 
   // Запускаем генерацию при изменении данных
   useEffect(() => {
-    if (roomImage && !isLoading) {
+    if (roomImage) {
       generateCompositeImage();
     }
-  }, [roomImage, roomItems, isLoading, generateCompositeImage]);
+  }, [roomImage, roomItems, generateCompositeImage]);
+
+  // Сброс флага загрузки монстра при смене изображения
+  useEffect(() => {
+    setMonsterLoaded(false);
+  }, [monsterImage]);
+
+  // Сообщаем родителю, когда и фон, и монстр загружены
+  useEffect(() => {
+    if (isReady && monsterLoaded && roomImage && monsterImage) {
+      onReady?.();
+    }
+  }, [isReady, monsterLoaded, roomImage, monsterImage, onReady]);
 
   // Управление видимостью canvas
   useEffect(() => {
@@ -241,7 +257,8 @@ const CompositeRoomRenderer: React.FC<CompositeRoomRendererProps> = ({
                 alt="Monster"
                 className="absolute bottom-[10%] left-1/2 w-1/2 transform -translate-x-1/2"
                 style={{ zIndex: 10 }}
-                onError={(e) => {
+                onLoad={() => setMonsterLoaded(true)}
+                onError={() => {
                   console.warn(
                     `Ошибка загрузки изображения монстра: ${monsterImage}`
                   );

--- a/src/components/CompositeRoomRenderer.tsx
+++ b/src/components/CompositeRoomRenderer.tsx
@@ -222,7 +222,26 @@ const CompositeRoomRenderer: React.FC<CompositeRoomRendererProps> = ({
           aria-hidden="true"
         />
 
-        {showSpinner ? (
+        {/* Готовое изображение (canvas видим через стиль) */}
+        <div className="relative w-full h-full">
+          {/* Монстр поверх */}
+          {monsterImage && (
+            <img
+              src={monsterImage}
+              alt="Monster"
+              className="absolute bottom-[10%] left-1/2 w-1/2 transform -translate-x-1/2"
+              style={{ zIndex: 10 }}
+              onLoad={() => setMonsterLoaded(true)}
+              onError={() => {
+                console.warn(
+                  `Ошибка загрузки изображения монстра: ${monsterImage}`
+                );
+              }}
+            />
+          )}
+        </div>
+
+        {showSpinner && (
           // Спиннер во время загрузки/генерации
           <div className="absolute inset-0 flex items-center justify-center bg-white/80">
             <div className="flex flex-col items-center gap-2">
@@ -236,7 +255,9 @@ const CompositeRoomRenderer: React.FC<CompositeRoomRendererProps> = ({
               </span>
             </div>
           </div>
-        ) : error ? (
+        )}
+
+        {error && (
           // Ошибка
           <div className="absolute inset-0 flex items-center justify-center bg-red-50">
             <div className="text-center p-4">
@@ -246,25 +267,6 @@ const CompositeRoomRenderer: React.FC<CompositeRoomRendererProps> = ({
               </div>
               <div className="text-red-600 text-xs max-w-xs">{error}</div>
             </div>
-          </div>
-        ) : (
-          // Готовое изображение (canvas видим через стиль)
-          <div className="relative w-full h-full">
-            {/* Монстр поверх */}
-            {monsterImage && (
-              <img
-                src={monsterImage}
-                alt="Monster"
-                className="absolute bottom-[10%] left-1/2 w-1/2 transform -translate-x-1/2"
-                style={{ zIndex: 10 }}
-                onLoad={() => setMonsterLoaded(true)}
-                onError={() => {
-                  console.warn(
-                    `Ошибка загрузки изображения монстра: ${monsterImage}`
-                  );
-                }}
-              />
-            )}
           </div>
         )}
       </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -216,10 +216,10 @@ const App: React.FC = () => {
 
     Promise.all([loadCharacteristics(), loadMonsterRoom(), loadImpacts()])
       .catch(() => {
-        if (!cancelled) setError("Ошибка при обновлении данных");
-      })
-      .finally(() => {
-        if (!cancelled) setIsMonsterLoading(false);
+        if (!cancelled) {
+          setError("Ошибка при обновлении данных");
+          setIsMonsterLoading(false);
+        }
       });
 
     return () => {
@@ -683,6 +683,7 @@ const App: React.FC = () => {
                   roomItems={roomItems}
                   isLoading={isMonsterLoading}
                   className="w-full"
+                  onReady={() => setIsMonsterLoading(false)}
                 />
 
                 <div className="mt-4 space-y-2 p-2">


### PR DESCRIPTION
## Summary
- ensure CompositeRoomRenderer notifies when all images are ready
- lock monster switch until room+monster images have loaded

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c1c8dfcd60832aa64400f76a0a2b40