### PR TITLE
Refresh raising screen after interactions

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -27,7 +27,7 @@ export const API_URLS = {
   characteristics: "https://functions.yandexcloud.net/d4eja3aglipp5f8hfb73",
   monsterroom: "https://functions.yandexcloud.net/d4eqemr3g0g9i1kbt5u0",
   impacts: "https://functions.yandexcloud.net/d4en3p6tiu5kcoe261mj",
-  impact: "https://functions.yandexcloud.net/d4een4tv1fhjs9o05ogj",
+  impact: "https://impactslauncher-production.up.railway.app/impact-exec",
 };
 
 // Образы и иконки

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -556,16 +556,16 @@ const App: React.FC = () => {
         );
         setInteractionData(response);
         setShowRaisingInteraction(true);
-
+        setIsLoading(false);
         await Promise.all([
           loadTeachEnergy(true),
           loadCharacteristics(),
-          // при необходимости: loadMonsterRoom(), loadImpacts()
+          loadMonsterRoom(),
+          loadImpacts(),
           loadMainMenu(),
         ]);
       } catch {
         setError("Ошибка при обновлении данных");
-      } finally {
         setIsLoading(false);
       }
     },
@@ -576,6 +576,8 @@ const App: React.FC = () => {
       apiService,
       loadTeachEnergy,
       loadCharacteristics,
+      loadMonsterRoom,
+      loadImpacts,
       loadMainMenu,
     ]
   );


### PR DESCRIPTION
## Summary
- update impact API endpoint to `impact-exec`
- reload monster visuals and interactions after applying an impact

## Testing
- `npm test --silent -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c28b44bba4832a92be18aab7402a64