### PR TITLE
feat: add energy replenishment modal

### DIFF
--- a/src/components/EnergyReplenishment.tsx
+++ b/src/components/EnergyReplenishment.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+
+interface EnergyReplenishmentProps {
+  onClose: () => void;
+}
+
+const OPTIONS = [
+  {
+    label: "Одна единица энергии",
+    price: "За просмотр рекламы",
+    icon: "https://storage.yandexcloud.net/svm/img/oneteachenergy.png",
+  },
+  {
+    label: "Десять единиц энергии",
+    price: "135 ₽",
+    icon: "https://storage.yandexcloud.net/svm/img/averagenumberteacherenergy.png",
+  },
+  {
+    label: "Девяносто единиц энергии",
+    price: "990 ₽",
+    icon: "https://storage.yandexcloud.net/svm/img/largenumberteachenergy.png",
+  },
+];
+
+const EnergyReplenishment: React.FC<EnergyReplenishmentProps> = ({ onClose }) => {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center z-[150] bg-black/60">
+      <div className="bg-gradient-to-br from-purple-100 to-orange-100 p-[2px] rounded-2xl shadow-2xl w-full max-w-md">
+        <div className="bg-white rounded-2xl p-6 space-y-6">
+          <h2 className="text-2xl font-bold text-purple-700 text-center">
+            Пополнение энергии
+          </h2>
+          <div className="space-y-4">
+            {OPTIONS.map((opt) => (
+              <div
+                key={opt.label}
+                className="flex items-center justify-between p-4 rounded-xl border border-purple-200 bg-purple-50 hover:bg-purple-100 cursor-pointer transition-colors"
+              >
+                <div className="flex items-center space-x-4">
+                  <img src={opt.icon} alt={opt.label} className="w-10 h-10" />
+                  <span className="text-purple-800 font-medium">
+                    {opt.label}
+                  </span>
+                </div>
+                <span className="text-purple-700">{opt.price}</span>
+              </div>
+            ))}
+          </div>
+          <button
+            onClick={onClose}
+            className="w-full bg-purple-500 hover:bg-purple-600 text-white py-2 rounded-lg"
+          >
+            Закрыть
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EnergyReplenishment;
+

--- a/src/components/EnergyReplenishment.tsx
+++ b/src/components/EnergyReplenishment.tsx
@@ -25,34 +25,30 @@ const OPTIONS = [
 const EnergyReplenishment: React.FC<EnergyReplenishmentProps> = ({ onClose }) => {
   return (
     <div className="fixed inset-0 flex items-center justify-center z-[150] bg-black/60">
-      <div className="bg-gradient-to-br from-purple-100 to-orange-100 p-[2px] rounded-2xl shadow-2xl w-full max-w-md">
-        <div className="bg-white rounded-2xl p-6 space-y-6">
-          <h2 className="text-2xl font-bold text-purple-700 text-center">
-            Пополнение энергии
-          </h2>
-          <div className="space-y-4">
-            {OPTIONS.map((opt) => (
-              <div
-                key={opt.label}
-                className="flex items-center justify-between p-4 rounded-xl border border-purple-200 bg-purple-50 hover:bg-purple-100 cursor-pointer transition-colors"
-              >
-                <div className="flex items-center space-x-4">
-                  <img src={opt.icon} alt={opt.label} className="w-10 h-10" />
-                  <span className="text-purple-800 font-medium">
-                    {opt.label}
-                  </span>
-                </div>
-                <span className="text-purple-700">{opt.price}</span>
+      <div className="bg-gradient-to-br from-purple-50 to-orange-50 rounded-2xl p-6 shadow-2xl w-full max-w-md space-y-6">
+        <h2 className="text-2xl font-bold text-purple-700 text-center">
+          Пополнение энергии
+        </h2>
+        <div className="space-y-4">
+          {OPTIONS.map((opt) => (
+            <div
+              key={opt.label}
+              className="flex items-center justify-between p-4 rounded-xl border border-purple-200 bg-purple-50 hover:bg-purple-100 cursor-pointer transition-colors"
+            >
+              <div className="flex items-center space-x-4">
+                <img src={opt.icon} alt={opt.label} className="h-[100px] w-auto" />
+                <span className="text-purple-800 font-medium">{opt.label}</span>
               </div>
-            ))}
-          </div>
-          <button
-            onClick={onClose}
-            className="w-full bg-purple-500 hover:bg-purple-600 text-white py-2 rounded-lg"
-          >
-            Закрыть
-          </button>
+              <span className="text-purple-700">{opt.price}</span>
+            </div>
+          ))}
         </div>
+        <button
+          onClick={onClose}
+          className="w-full bg-purple-500 hover:bg-purple-600 text-white py-2 rounded-lg"
+        >
+          Закрыть
+        </button>
       </div>
     </div>
   );

--- a/src/components/EnergySection.tsx
+++ b/src/components/EnergySection.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { IMAGES } from "../constants";
 import { formatTimer } from "../utils";
+import EnergyReplenishment from "./EnergyReplenishment";
 
 interface EnergySectionProps {
   teachEnergy: number;
@@ -11,6 +12,7 @@ const EnergySection: React.FC<EnergySectionProps> = ({
   teachEnergy,
   timer,
 }) => {
+  const [showEnergyModal, setShowEnergyModal] = useState(false);
   return (
     <div className="flex flex-col justify-between h-full items-center border border-gray-300 p-3 bg-purple-50 w-full md:w-auto md:min-w-[200px]">
       {/* Группа для иконки и значения энергии */}
@@ -29,9 +31,15 @@ const EnergySection: React.FC<EnergySectionProps> = ({
       )}
 
       {/* Кнопка */}
-      <button className="w-full mt-2 bg-gray-300 text-gray-500 px-4 py-2 rounded cursor-not-allowed">
+      <button
+        onClick={() => setShowEnergyModal(true)}
+        className="w-full mt-2 bg-purple-500 hover:bg-purple-600 text-white px-4 py-2 rounded"
+      >
         Пополнить энергию
       </button>
+      {showEnergyModal && (
+        <EnergyReplenishment onClose={() => setShowEnergyModal(false)} />
+      )}
     </div>
   );
 };

--- a/src/components/RaisingSection.tsx
+++ b/src/components/RaisingSection.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState } from "react";
+import EnergyReplenishment from "./EnergyReplenishment";
 
 // Локальные типы для избежания проблем с импортами
 interface Monster {
@@ -76,6 +77,7 @@ const RaisingSection: React.FC<RaisingSectionProps> = ({
   onMonsterSwitch,
   onImpactClick,
 }) => {
+  const [showEnergyModal, setShowEnergyModal] = useState(false);
   // Вычисления для enduranceIcon (иконка выносливости)
   const enduranceIcon = characteristics.find((c) => c.id === 10012)?.icon || "";
 
@@ -132,7 +134,10 @@ const RaisingSection: React.FC<RaisingSectionProps> = ({
             </span>
           )}
 
-          <button className="w-full mt-2 bg-gray-300 text-gray-500 px-4 py-2 rounded cursor-not-allowed">
+          <button
+            onClick={() => setShowEnergyModal(true)}
+            className="w-full mt-2 bg-purple-500 hover:bg-purple-600 text-white px-4 py-2 rounded"
+          >
             Пополнить энергию
           </button>
         </div>
@@ -251,6 +256,9 @@ const RaisingSection: React.FC<RaisingSectionProps> = ({
           ))}
         </div>
       </div>
+      {showEnergyModal && (
+        <EnergyReplenishment onClose={() => setShowEnergyModal(false)} />
+      )}
     </div>
   );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ import Spinner from "./components/Spinner";
 import MobileMainMenu from "./components/MobileMainMenu";
 import DesktopMenu from "./components/DesktopMenu";
 import CompositeRoomRenderer from "./components/CompositeRoomRenderer";
+import EnergyReplenishment from "./components/EnergyReplenishment";
 
 // Типы
 import {
@@ -79,6 +80,7 @@ const App: React.FC = () => {
 
   const [showNotifications, setShowNotifications] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
+  const [showEnergyModal, setShowEnergyModal] = useState<boolean>(false);
 
   const [showRaisingInteraction, setShowRaisingInteraction] =
     useState<boolean>(false);
@@ -698,7 +700,10 @@ const App: React.FC = () => {
                   </span>
                 )}
 
-                <button className="w-full mt-2 bg-gray-300 text-gray-500 px-4 py-2 rounded cursor-not-allowed">
+                <button
+                  onClick={() => setShowEnergyModal(true)}
+                  className="w-full mt-2 bg-purple-500 hover:bg-purple-600 text-white px-4 py-2 rounded"
+                >
                   Пополнить энергию
                 </button>
               </div>
@@ -812,6 +817,10 @@ const App: React.FC = () => {
         selectedMenuSequence === MENU_SEQUENCES.ACCOUNT && (
           <Account userId={userId} />
         )}
+
+      {showEnergyModal && (
+        <EnergyReplenishment onClose={() => setShowEnergyModal(false)} />
+      )}
 
       {/* Подвал с ссылкой на оферту */}
       <footer className="bg-gradient-to-r from-purple-500 to-orange-500 text-white py-2 mt-8">


### PR DESCRIPTION
## Summary
- add energy replenishment modal with purchase badges
- open modal from "Пополнить энергию" button on raising screen
- wire energy sections to display modal

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c7108ac838832ab186d50b7577f0ea