### PR TITLE
Add buy another monster button on raising screen

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -620,12 +620,9 @@ const App: React.FC = () => {
       {!showRaisingInteraction &&
         selectedMenuSequence === MENU_SEQUENCES.RAISING && (
           <div className="px-4 mt-2 md:mt-4">
-            <button
-              className="w-full md:w-1/2 bg-purple-400 hover:bg-purple-500 text-white px-4 py-2 rounded block mx-auto"
-              onClick={() => {}}
-            >
+            <div className="w-full md:w-1/2 bg-gradient-to-r from-purple-400 to-purple-600 text-white px-4 py-3 rounded-lg shadow-md mx-auto text-center font-semibold">
               Купить еще одного монстра
-            </button>
+            </div>
           </div>
         )}
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -617,6 +617,18 @@ const App: React.FC = () => {
         onToggleNotifications={() => setShowNotifications(!showNotifications)}
       />
 
+      {!showRaisingInteraction &&
+        selectedMenuSequence === MENU_SEQUENCES.RAISING && (
+          <div className="px-4 mt-2 md:mt-4">
+            <button
+              className="w-full md:w-1/2 bg-purple-400 hover:bg-purple-500 text-white px-4 py-2 rounded block mx-auto"
+              onClick={() => {}}
+            >
+              Купить еще одного монстра
+            </button>
+          </div>
+        )}
+
       {showNotifications && (
         <div className="bg-orange-100 p-4 shadow-md">Оповещения</div>
       )}


### PR DESCRIPTION
## Summary
- add "Купить еще одного монстра" button below the menu on the Raising screen
- responsive width: full on mobile, half-width on desktop
- style similar to energy button with slight color variation

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c722cb9054832a98aaddb9a412e386