### PR TITLE
Show Yandex fullscreen ad before closing raising interaction

### DIFF
--- a/src/RaisingInteraction.tsx
+++ b/src/RaisingInteraction.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useCallback } from "react";
+import { useYandexFullscreenAd } from "./hooks/useYandexFullscreenAd";
 
 interface CharacteristicChange {
   characteristicsid: number;
@@ -51,6 +52,7 @@ const RaisingInteraction: React.FC<RaisingInteractionProps> = ({
   onClose,
 }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const { showAd } = useYandexFullscreenAd();
 
   // единые классы ширины для всех основных блоков
   const commonWidth = "w-full max-w-[92%] md:max-w-[80%] lg:max-w-[75%]";
@@ -60,6 +62,10 @@ const RaisingInteraction: React.FC<RaisingInteractionProps> = ({
     window.scrollTo({ top: 0, left: 0, behavior: "auto" });
     if (videoRef.current) videoRef.current.volume = 0.2;
   }, []);
+
+  const handleClose = useCallback(() => {
+    void showAd().then(onClose);
+  }, [showAd, onClose]);
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-purple-200 to-orange-200 p-2 sm:p-4">
@@ -276,7 +282,7 @@ const RaisingInteraction: React.FC<RaisingInteractionProps> = ({
 
       <div className="flex justify-center">
         <button
-          onClick={onClose}
+          onClick={handleClose}
           className="bg-purple-500 text-white px-5 py-2 rounded"
         >
           Закрыть

--- a/src/hooks/useYandexFullscreenAd.ts
+++ b/src/hooks/useYandexFullscreenAd.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect } from "react";
+
+const SCRIPT_SRC = "https://yandex.ru/ads/system/context.js";
+const BLOCK_ID = "R-A-17258459-2";
+const MOBILE_USER_AGENT_REGEX = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i;
+
+declare global {
+  interface Window {
+    Ya?: {
+      Context?: {
+        AdvManager?: {
+          render: (options: {
+            blockId: string;
+            type: string;
+            platform: string;
+          }) => void;
+        };
+      };
+    };
+    yaContextCb?: Array<() => void>;
+  }
+}
+
+const isDesktopDevice = (): boolean => {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  return !MOBILE_USER_AGENT_REGEX.test(navigator.userAgent);
+};
+
+export const useYandexFullscreenAd = () => {
+  const ensureScript = useCallback(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    window.yaContextCb = window.yaContextCb || [];
+
+    if (document.querySelector(`script[src="${SCRIPT_SRC}"]`)) {
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = SCRIPT_SRC;
+    script.async = true;
+    document.head.appendChild(script);
+  }, []);
+
+  useEffect(() => {
+    if (!isDesktopDevice()) {
+      return;
+    }
+
+    ensureScript();
+  }, [ensureScript]);
+
+  const showAd = useCallback((): Promise<void> => {
+    if (!isDesktopDevice() || typeof window === "undefined") {
+      return Promise.resolve();
+    }
+
+    ensureScript();
+
+    return new Promise<void>((resolve) => {
+      let resolved = false;
+      const finish = () => {
+        if (!resolved) {
+          resolved = true;
+          resolve();
+        }
+      };
+
+      const timeoutId = window.setTimeout(finish, 3000);
+
+      const renderAd = () => {
+        window.clearTimeout(timeoutId);
+        try {
+          window.Ya?.Context?.AdvManager?.render({
+            blockId: BLOCK_ID,
+            type: "fullscreen",
+            platform: "desktop",
+          });
+        } catch (error) {
+          console.error("Не удалось отобразить рекламу Яндекса", error);
+        }
+        finish();
+      };
+
+      if (window.Ya?.Context?.AdvManager) {
+        renderAd();
+        return;
+      }
+
+      window.yaContextCb = window.yaContextCb || [];
+      window.yaContextCb.push(renderAd);
+    });
+  }, [ensureScript]);
+
+  return { showAd };
+};


### PR DESCRIPTION
## Summary
- add a reusable hook that loads the Yandex RTB script and renders a fullscreen desktop ad
- call the new hook when closing the RaisingInteraction screen so the ad is shown before returning to "Воспитание"

## Testing
- npm run build *(fails: TS2345 argument of type 'number | null' is not assignable to parameter of type 'number' in src/index.tsx — pre-existing type issue)*

------
https://chatgpt.com/codex/tasks/task_e_68c92c25bec0832a89e025686ec0d234