### PR TITLE
Update Yandex fullscreen ad handling

### DIFF
--- a/src/RaisingInteraction.tsx
+++ b/src/RaisingInteraction.tsx
@@ -63,8 +63,9 @@ const RaisingInteraction: React.FC<RaisingInteractionProps> = ({
     if (videoRef.current) videoRef.current.volume = 0.2;
   }, []);
 
-  const handleClose = useCallback(() => {
-    void showAd().then(onClose);
+  const handleClose = useCallback(async () => {
+    await showAd();
+    onClose();
   }, [showAd, onClose]);
 
   return (


### PR DESCRIPTION
## Summary
- update the Yandex fullscreen ad hook to rely on AdvManager callbacks and new render options
- wait for the fullscreen ad to finish before closing the RaisingInteraction screen

## Testing
- npm run build *(fails: TS2345: Argument of type 'number | null' is not assignable to parameter of type 'number' in apiService.getCharacteristics call)*

------
https://chatgpt.com/codex/tasks/task_e_68c9347d6c34832ab609a383ebf48d24