### PR TITLE
Remove single energy option from energy replenishment modal

### DIFF
--- a/src/components/EnergyReplenishment.tsx
+++ b/src/components/EnergyReplenishment.tsx
@@ -1,25 +1,10 @@
-import React, { useCallback, useEffect, useState } from "react";
-import axios from "axios";
-import Spinner from "./Spinner";
-import { API_URLS } from "../constants";
+import React from "react";
 
 interface EnergyReplenishmentProps {
   onClose: () => void;
-  userId: number | null;
-}
-
-interface TeachEnergyBarterEnableResponse {
-  teachenergybarterenable: boolean | "true" | "false";
-  teachenergybarterenabletime?: string;
 }
 
 const OPTIONS = [
-  {
-    id: "single",
-    label: "Одна единица энергии",
-    price: "За просмотр рекламы",
-    icon: "https://storage.yandexcloud.net/svm/img/oneteachenergy.png",
-  },
   {
     id: "ten",
     label: "Десять единиц энергии",
@@ -36,187 +21,31 @@ const OPTIONS = [
 
 const EnergyReplenishment: React.FC<EnergyReplenishmentProps> = ({
   onClose,
-  userId,
 }) => {
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isOneUnitEnabled, setIsOneUnitEnabled] = useState<boolean>(false);
-  const [availabilityTime, setAvailabilityTime] = useState<Date | null>(null);
-  const [countdown, setCountdown] = useState<string>("");
-
-  const fetchAvailability = useCallback(async () => {
-    if (userId === null || userId === undefined) {
-      setError("Не удалось определить пользователя.");
-      setIsOneUnitEnabled(false);
-      setAvailabilityTime(null);
-      setCountdown("");
-      setLoading(false);
-      return;
-    }
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const { data } = await axios.post<TeachEnergyBarterEnableResponse>(
-        API_URLS.teachenergybarterenable,
-        { userId }
-      );
-
-      const rawValue = data.teachenergybarterenable;
-      const enabled =
-        typeof rawValue === "string"
-          ? rawValue.toLowerCase() === "true"
-          : Boolean(rawValue);
-
-      setIsOneUnitEnabled(enabled);
-
-      if (!enabled && data.teachenergybarterenabletime) {
-        const parsed = new Date(data.teachenergybarterenabletime);
-        if (!Number.isNaN(parsed.getTime())) {
-          if (parsed.getTime() <= Date.now()) {
-            setIsOneUnitEnabled(true);
-            setAvailabilityTime(null);
-            setCountdown("");
-          } else {
-            setAvailabilityTime(parsed);
-          }
-        } else {
-          setAvailabilityTime(null);
-          setCountdown("");
-        }
-      } else {
-        setAvailabilityTime(null);
-        setCountdown("");
-      }
-    } catch (err) {
-      console.error(
-        "Ошибка при загрузке статуса пополнения энергии",
-        err
-      );
-      setError("Не удалось загрузить информацию о пополнении энергии.");
-      setIsOneUnitEnabled(false);
-      setAvailabilityTime(null);
-      setCountdown("");
-    } finally {
-      setLoading(false);
-    }
-  }, [userId]);
-
-  useEffect(() => {
-    fetchAvailability();
-  }, [fetchAvailability]);
-
-  useEffect(() => {
-    if (!availabilityTime) {
-      setCountdown("");
-      return;
-    }
-
-    const updateCountdown = () => {
-      const now = new Date();
-      const diff = availabilityTime.getTime() - now.getTime();
-      if (diff <= 0) {
-        setCountdown("0 часов 00 минут");
-        return;
-      }
-      const totalMinutes = Math.floor(diff / (1000 * 60));
-      const hours = Math.floor(totalMinutes / 60);
-      const minutes = totalMinutes % 60;
-      setCountdown(
-        `${hours} часов ${minutes.toString().padStart(2, "0")} минут`
-      );
-    };
-
-    updateCountdown();
-
-    const intervalId = window.setInterval(updateCountdown, 60000);
-
-    return () => window.clearInterval(intervalId);
-  }, [availabilityTime]);
-
-  useEffect(() => {
-    if (!availabilityTime || userId === null || userId === undefined) {
-      return;
-    }
-
-    const timeoutDelay = availabilityTime.getTime() - Date.now();
-    if (timeoutDelay <= 0) {
-      fetchAvailability();
-      return;
-    }
-
-    const safeDelay = Math.min(timeoutDelay, 2147483647);
-    const timeoutId = window.setTimeout(() => {
-      fetchAvailability();
-    }, safeDelay);
-
-    return () => window.clearTimeout(timeoutId);
-  }, [availabilityTime, fetchAvailability, userId]);
-
   return (
     <div className="fixed inset-0 flex items-center justify-center z-[150] bg-black/60">
       <div className="bg-gradient-to-br from-purple-50 to-orange-50 rounded-2xl p-6 shadow-2xl w-full max-w-md space-y-6">
         <h2 className="text-2xl font-bold text-purple-700 text-center">
           Пополнение энергии
         </h2>
-
-        {error && (
-          <div className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-            {error}
-          </div>
-        )}
-
-        <div className="relative">
-          <div
-            className={`space-y-4 ${
-              loading ? "pointer-events-none opacity-50" : ""
-            }`}
-          >
-            {OPTIONS.map((opt) => {
-              const isOneUnitOption = opt.id === "single";
-              const isDisabled =
-                isOneUnitOption && (loading || !isOneUnitEnabled);
-
-              return (
-                <div key={opt.id} className="relative">
-                  <button
-                    type="button"
-                    disabled={isOneUnitOption ? isDisabled : false}
-                    className={`flex w-full items-center justify-between rounded-xl border border-purple-200 bg-purple-50 p-4 transition-colors ${
-                      isDisabled
-                        ? "cursor-not-allowed opacity-70"
-                        : "cursor-pointer hover:bg-purple-100"
-                    }`}
-                  >
-                    <div className="flex items-center space-x-4">
-                      <img
-                        src={opt.icon}
-                        alt={opt.label}
-                        className="h-[100px] w-auto"
-                      />
-                      <span className="text-purple-800 font-medium">
-                        {opt.label}
-                      </span>
-                    </div>
-                    <span className="text-purple-700">{opt.price}</span>
-                  </button>
-
-                  {isOneUnitOption && !loading && !error && !isOneUnitEnabled && (
-                    <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-xl bg-black/60 px-4 py-3 text-center text-sm font-medium text-white">
-                      Будет доступно через {countdown || "-- часов -- минут"}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-
-          {loading && (
-            <div className="absolute inset-0 flex items-center justify-center rounded-2xl bg-white/70">
-              <Spinner size="small" />
-            </div>
-          )}
+        <div className="space-y-4">
+          {OPTIONS.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              className="flex w-full items-center justify-between rounded-xl border border-purple-200 bg-purple-50 p-4 transition-colors cursor-pointer hover:bg-purple-100"
+            >
+              <div className="flex items-center space-x-4">
+                <img
+                  src={opt.icon}
+                  alt={opt.label}
+                  className="h-[100px] w-auto"
+                />
+                <span className="text-purple-800 font-medium">{opt.label}</span>
+              </div>
+              <span className="text-purple-700">{opt.price}</span>
+            </button>
+          ))}
         </div>
 
         <button

--- a/src/components/EnergySection.tsx
+++ b/src/components/EnergySection.tsx
@@ -6,13 +6,11 @@ import EnergyReplenishment from "./EnergyReplenishment";
 interface EnergySectionProps {
   teachEnergy: number;
   timer: number;
-  userId: number | null;
 }
 
 const EnergySection: React.FC<EnergySectionProps> = ({
   teachEnergy,
   timer,
-  userId,
 }) => {
   const [showEnergyModal, setShowEnergyModal] = useState(false);
   return (
@@ -40,10 +38,7 @@ const EnergySection: React.FC<EnergySectionProps> = ({
         Пополнить энергию
       </button>
       {showEnergyModal && (
-        <EnergyReplenishment
-          onClose={() => setShowEnergyModal(false)}
-          userId={userId}
-        />
+        <EnergyReplenishment onClose={() => setShowEnergyModal(false)} />
       )}
     </div>
   );

--- a/src/components/RaisingSection.tsx
+++ b/src/components/RaisingSection.tsx
@@ -49,7 +49,6 @@ interface RaisingSectionProps {
   isMonsterLoading: boolean;
   onMonsterSwitch: (monsterId: number) => void;
   onImpactClick: (impact: MonsterImpact) => void;
-  userId: number | null;
 }
 
 const formatTimer = (timeInSeconds: number): string => {
@@ -77,7 +76,6 @@ const RaisingSection: React.FC<RaisingSectionProps> = ({
   isMonsterLoading,
   onMonsterSwitch,
   onImpactClick,
-  userId,
 }) => {
   const [showEnergyModal, setShowEnergyModal] = useState(false);
   // Вычисления для enduranceIcon (иконка выносливости)
@@ -259,10 +257,7 @@ const RaisingSection: React.FC<RaisingSectionProps> = ({
         </div>
       </div>
       {showEnergyModal && (
-        <EnergyReplenishment
-          onClose={() => setShowEnergyModal(false)}
-          userId={userId}
-        />
+        <EnergyReplenishment onClose={() => setShowEnergyModal(false)} />
       )}
     </div>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -829,10 +829,7 @@ const App: React.FC = () => {
         )}
 
       {showEnergyModal && (
-        <EnergyReplenishment
-          onClose={() => setShowEnergyModal(false)}
-          userId={userId}
-        />
+        <EnergyReplenishment onClose={() => setShowEnergyModal(false)} />
       )}
 
       {/* Подвал с ссылкой на оферту */}


### PR DESCRIPTION
## Summary
- remove the single-energy badge and related availability logic from the energy replenishment modal
- update energy-related sections to use the simplified modal props

## Testing
- yarn build *(fails: TS2345: Argument of type 'number | null' is not assignable to parameter of type 'number' in src/hooks/useBootstrap.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc2b77714832aafa5ba821357e013