### PR TITLE
Improve competition energy replenishment modal UX

### DIFF
--- a/src/components/CompetitionEnergy.tsx
+++ b/src/components/CompetitionEnergy.tsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import { API_URLS, IMAGES } from "../constants";
 import { formatTimer } from "../utils";
 import { CompetitionEnergyResponse } from "../types";
+import CompetitionEnergyReplenishment from "./CompetitionEnergyReplenishment";
 
 interface Props {
   userId: number;
@@ -12,6 +13,7 @@ const CompetitionEnergy: React.FC<Props> = ({ userId }) => {
   const [energy, setEnergy] = useState<number | null>(null);
   const [next, setNext] = useState<string>("");
   const [timer, setTimer] = useState<number>(0);
+  const [showReplenishment, setShowReplenishment] = useState(false);
 
   const loadData = async () => {
     try {
@@ -54,31 +56,37 @@ const CompetitionEnergy: React.FC<Props> = ({ userId }) => {
   if (energy == null) return null;
 
   return (
-    <div className="w-full flex justify-center mb-6 md:mb-0">
-      <div className="flex flex-col items-center md:justify-between rounded-xl border-2 border-blue-300 bg-blue-50 shadow-md p-4 w-full md:w-auto md:h-[282px]">
-        <div className="flex items-center gap-3">
-          <img
-            src={IMAGES.competitionEnergy}
-            alt="Энергия на соревнования"
-            className="w-9 h-10"
-          />
-          <span className="text-xl font-semibold text-blue-800">
-            Энергия: {energy}
-          </span>
+    <>
+      <div className="w-full flex justify-center mb-6 md:mb-0">
+        <div className="flex flex-col items-center md:justify-between rounded-xl border-2 border-blue-300 bg-blue-50 shadow-md p-4 w-full md:w-auto md:h-[282px]">
+          <div className="flex items-center gap-3">
+            <img
+              src={IMAGES.competitionEnergy}
+              alt="Энергия на соревнования"
+              className="w-9 h-10"
+            />
+            <span className="text-xl font-semibold text-blue-800">
+              Энергия: {energy}
+            </span>
+          </div>
+          {energy < 5 && (
+            <span className="mt-2 text-sm text-blue-700">
+              До бесплатного пополнения энергии {formatTimer(timer)}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => setShowReplenishment(true)}
+            className="mt-3 w-full rounded-lg bg-blue-500 px-4 py-2 text-white transition-colors hover:bg-blue-600"
+          >
+            Пополнить энергию
+          </button>
         </div>
-        {energy < 5 && (
-          <span className="mt-2 text-sm text-blue-700">
-            До бесплатного пополнения энергии {formatTimer(timer)}
-          </span>
-        )}
-        <button
-          className="mt-3 px-4 py-2 rounded bg-blue-200 text-blue-500 cursor-not-allowed"
-          disabled
-        >
-          Пополнить энергию
-        </button>
       </div>
-    </div>
+      {showReplenishment && (
+        <CompetitionEnergyReplenishment onClose={() => setShowReplenishment(false)} />
+      )}
+    </>
   );
 };
 

--- a/src/components/CompetitionEnergyReplenishment.tsx
+++ b/src/components/CompetitionEnergyReplenishment.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect } from "react";
+
+interface CompetitionEnergyReplenishmentProps {
+  onClose: () => void;
+}
+
+const BADGES = [
+  {
+    id: "ten",
+    label: "Десять единиц энергии",
+    price: "270 ₽",
+    icon: "https://storage.yandexcloud.net/svm/img/compenerjymid.png",
+  },
+  {
+    id: "ninety",
+    label: "Девяносто единиц энергии",
+    price: "1980 ₽",
+    icon: "https://storage.yandexcloud.net/svm/img/compenerjymany.png",
+  },
+];
+
+const CompetitionEnergyReplenishment: React.FC<CompetitionEnergyReplenishmentProps> = ({
+  onClose,
+}) => {
+  useEffect(() => {
+    const { overflow } = document.body.style;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = overflow;
+    };
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-[200] overflow-y-auto bg-black/70">
+      <div className="flex min-h-full items-start justify-center px-4 py-10 md:items-center md:py-16">
+        <div className="relative w-full max-w-4xl rounded-3xl bg-gradient-to-br from-slate-950 via-slate-900 to-black p-6 text-white shadow-[0_25px_80px_rgba(0,0,0,0.55)] max-h-[calc(100vh-4rem)] overflow-y-auto md:p-8">
+          <button
+            type="button"
+            aria-label="Закрыть окно пополнения энергии"
+            onClick={onClose}
+            className="absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-700 bg-slate-900/70 text-slate-300 transition-colors hover:border-purple-500 hover:text-white"
+          >
+            ×
+          </button>
+          <div className="space-y-6 pt-4 md:pt-2">
+            <div className="space-y-2 text-center">
+              <h2 className="text-2xl font-semibold text-slate-100 md:text-3xl">
+                Пополнение энергии для соревнований
+              </h2>
+              <p className="text-sm text-slate-400 md:text-base">
+                Выберите подходящий пакет, чтобы вернуться в соревнования без паузы.
+              </p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              {BADGES.map((badge) => (
+                <div
+                  key={badge.id}
+                  className="group flex h-full flex-col justify-between rounded-2xl border border-slate-800/80 bg-slate-900/80 p-5 text-left shadow-lg transition-all hover:border-purple-500/60 hover:bg-slate-900 hover:shadow-[0_0_35px_rgba(168,85,247,0.35)]"
+                >
+                  <div className="flex flex-1 flex-col items-center gap-4 md:flex-row md:items-stretch md:gap-6">
+                    <div className="flex w-full justify-center md:w-auto">
+                      <img
+                        src={badge.icon}
+                        alt={badge.label}
+                        className="w-28 max-w-[140px] rounded-xl bg-slate-950/60 p-2 shadow-inner"
+                        style={{ aspectRatio: "2 / 3" }}
+                      />
+                    </div>
+                    <div className="flex flex-1 flex-col items-center gap-3 text-center md:items-start md:text-left">
+                      <span className="text-lg font-semibold text-slate-100 md:text-xl">
+                        {badge.label}
+                      </span>
+                      <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
+                        Цена
+                      </span>
+                      <span className="text-2xl font-bold text-purple-300 md:text-3xl">
+                        {badge.price}
+                      </span>
+                    </div>
+                  </div>
+                  <span className="mt-4 text-center text-xs text-slate-400 md:text-left">
+                    Оптимальный выбор для восстановления энергии в нужный момент.
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            <div className="flex justify-center">
+              <button
+                type="button"
+                onClick={onClose}
+                className="w-full max-w-xs rounded-full bg-purple-600 px-6 py-3 text-sm font-semibold uppercase tracking-wider text-white shadow-lg transition-colors hover:bg-purple-500"
+              >
+                Закрыть
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CompetitionEnergyReplenishment;


### PR DESCRIPTION
## Summary
- lock background scrolling while the competition energy replenishment modal is open
- adjust the modal layout to align from the top on small screens and keep the close button visible
- allow the modal content to scroll within the overlay using viewport-based height limits

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cdc0c48e28832aba66e1c716b64a58