### PR TITLE
Handle monster purchase link creation

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -959,6 +959,7 @@ const App: React.FC = () => {
           types={monsterTypes}
           loading={monsterTypesLoading}
           error={monsterTypesError}
+          userId={userId}
           onClose={() => setShowMonsterTypeSelector(false)}
           onRetry={handleRetryMonsterTypes}
         />


### PR DESCRIPTION
## Summary
- call the payment link creation endpoint when an active monster type badge is clicked
- disable monster type buttons during link creation, show a spinner, and surface API errors in a dialog
- redirect to the returned payment link and provide the component with the current user id

## Testing
- npm run build *(fails: existing TypeScript syntax `satisfies` triggers "Syntax error: ';' expected" from eslint during build)*

------
https://chatgpt.com/codex/tasks/task_e_68d171c20518832ab6f681b2632d78c5