### PR TITLE
Handle VK initialization parameters

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -92,6 +92,39 @@ export async function withInfiniteRetryAndTimeout<T>(
   return requestPromise;
 }
 
+export const getVKParams = (): {
+  VK: boolean;
+  sign: string | null;
+  vkUserId: string | null;
+} => {
+  if (typeof window === "undefined") {
+    return {
+      VK: false,
+      sign: null,
+      vkUserId: null,
+    };
+  }
+
+  const search = window.location?.search ?? "";
+  const params = new URLSearchParams(search);
+
+  if (!params.has("vk_user_id")) {
+    return {
+      VK: false,
+      sign: null,
+      vkUserId: null,
+    };
+  }
+
+  const VK = true;
+
+  return {
+    VK,
+    sign: params.get("sign"),
+    vkUserId: params.get("vk_user_id"),
+  };
+};
+
 // Остальные функции остаются без изменений
 export const invalidateImageCache = (url: string): string => {
   const timestamp = Date.now();


### PR DESCRIPTION
## Summary
- add helper to extract VK-specific query parameters from the URL
- adjust init request payload to send VK fingerprint and user id when available
- hide the Account menu item when the app is opened via VK parameters

## Testing
- CI=true npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d43bee4ed8832a8548c59880319bd7