### PR TITLE
Show VK prices for monster selection

### DIFF
--- a/src/components/MonsterTypeSelector.tsx
+++ b/src/components/MonsterTypeSelector.tsx
@@ -6,6 +6,7 @@ type MonsterTypeSelectorProps = {
   loading: boolean;
   error: string;
   userId: number | null;
+  isVK: boolean;
   onClose: () => void;
   onRetry: () => void;
 };
@@ -15,11 +16,15 @@ interface CreatePaymentLinkResponse {
   errortext?: string | null;
 }
 
+const VK_PRICE_ICON_URL =
+  "https://storage.yandexcloud.net/svm/img/service_icons/vk.png";
+
 const MonsterTypeSelector: React.FC<MonsterTypeSelectorProps> = ({
   types,
   loading,
   error,
   userId,
+  isVK,
   onClose,
   onRetry,
 }) => {
@@ -163,8 +168,13 @@ const MonsterTypeSelector: React.FC<MonsterTypeSelectorProps> = ({
               ) : (
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 sm:gap-6">
                   {types.map((type) => {
+                    const shouldUseVkPrice =
+                      isVK && typeof type.vkprice === "number";
+                    const priceValue = shouldUseVkPrice
+                      ? type.vkprice!
+                      : type.price;
                     const formattedPrice = new Intl.NumberFormat("ru-RU").format(
-                      type.price
+                      priceValue
                     );
 
                     return (
@@ -206,11 +216,20 @@ const MonsterTypeSelector: React.FC<MonsterTypeSelectorProps> = ({
                               <span className="text-lg font-semibold text-purple-900">
                                 {type.name}
                               </span>
-                              <span className="inline-flex items-baseline gap-1 rounded-full bg-gradient-to-r from-orange-400/10 to-purple-500/10 px-3 py-1 text-sm font-bold text-orange-600">
+                              <span className="inline-flex items-center gap-1 rounded-full bg-gradient-to-r from-orange-400/10 to-purple-500/10 px-3 py-1 text-sm font-bold text-orange-600">
                                 {formattedPrice}
-                                <span className="text-xs font-semibold text-purple-700">
-                                  ₽
-                                </span>
+                                {shouldUseVkPrice ? (
+                                  <img
+                                    src={VK_PRICE_ICON_URL}
+                                    alt="VK Pay"
+                                    className="h-4 w-4"
+                                    loading="lazy"
+                                  />
+                                ) : (
+                                  <span className="text-xs font-semibold text-purple-700">
+                                    ₽
+                                  </span>
+                                )}
                               </span>
                             </div>
                             <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-purple-500">

--- a/src/hooks/useBootstrap.ts
+++ b/src/hooks/useBootstrap.ts
@@ -146,13 +146,15 @@ export const useBootstrap = (apiService: ApiService): UseBootstrapResult => {
           throw new Error("Не удалось определить выбранного монстра");
         }
 
+        const ensuredMonsterId: number = selectedMonsterLocal;
+
         setTeachEnergy(energyRes.teachenergy);
         setNextReplenishment(energyRes.nextfreereplenishment);
 
         // Этап 3: Параллельная загрузка
         const [characteristicsRes, roomRes, impactsRes] = await Promise.all([
           withInfiniteRetryAndTimeout(
-            () => apiService.getCharacteristics(selectedMonsterLocal),
+            () => apiService.getCharacteristics(ensuredMonsterId),
             5000,
             "characteristics",
             (error) => console.error(error)
@@ -161,7 +163,7 @@ export const useBootstrap = (apiService: ApiService): UseBootstrapResult => {
             return res;
           }),
           withInfiniteRetryAndTimeout(
-            () => apiService.getMonsterRoom(selectedMonsterLocal),
+            () => apiService.getMonsterRoom(ensuredMonsterId),
             5000,
             "monsterroom",
             (error) => console.error(error)
@@ -170,7 +172,7 @@ export const useBootstrap = (apiService: ApiService): UseBootstrapResult => {
             return res;
           }),
           withInfiniteRetryAndTimeout(
-            () => apiService.getImpacts(selectedMonsterLocal),
+            () => apiService.getImpacts(ensuredMonsterId),
             5000,
             "impacts",
             (error) => console.error(error)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,7 @@ export interface MonsterTypeInfo {
   image: string;
   price: number;
   activity: boolean;
+  vkprice?: number | null;
 }
 
 export interface MonstersResponse {


### PR DESCRIPTION
## Summary
- show VK-specific prices and icon in the monster purchase selector when launched inside VK
- parse and store vkprice values from the monster types API while passing VK flag through the app
- add stronger null guards during bootstrap flows to satisfy type checking

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d44c7db768832a87a24a94601ff192