### PR TITLE
Adjust energy replenishment pricing for VK

### DIFF
--- a/src/components/EnergyReplenishment.tsx
+++ b/src/components/EnergyReplenishment.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 interface EnergyReplenishmentProps {
   onClose: () => void;
   userId: number | null;
+  isVK?: boolean;
 }
 
 interface CreatePaymentLinkResponse {
@@ -13,23 +14,29 @@ interface CreatePaymentLinkResponse {
 interface EnergyOption {
   id: string;
   label: string;
-  price: string;
+  price: number;
+  vkPrice?: number;
   icon: string;
   invoiceTypeId: number;
 }
+
+const VK_PRICE_ICON_URL =
+  "https://storage.yandexcloud.net/svm/img/service_icons/vk.png";
 
 const OPTIONS: EnergyOption[] = [
   {
     id: "ten",
     label: "Десять единиц энергии",
-    price: "135 ₽",
+    price: 135,
+    vkPrice: 20,
     icon: "https://storage.yandexcloud.net/svm/img/averagenumberteacherenergy.png",
     invoiceTypeId: 7,
   },
   {
     id: "ninety",
     label: "Девяносто единиц энергии",
-    price: "990 ₽",
+    price: 990,
+    vkPrice: 142,
     icon: "https://storage.yandexcloud.net/svm/img/largenumberteachenergy.png",
     invoiceTypeId: 8,
   },
@@ -38,6 +45,7 @@ const OPTIONS: EnergyOption[] = [
 const EnergyReplenishment: React.FC<EnergyReplenishmentProps> = ({
   onClose,
   userId,
+  isVK = false,
 }) => {
   const [dialogMessage, setDialogMessage] = useState<string | null>(null);
   const [activeOptionId, setActiveOptionId] = useState<string | null>(null);
@@ -112,29 +120,44 @@ const EnergyReplenishment: React.FC<EnergyReplenishmentProps> = ({
           Пополнение энергии
         </h2>
         <div className="space-y-4">
-          {OPTIONS.map((opt) => (
-            <button
-              key={opt.id}
-              type="button"
-              onClick={() => handleOptionClick(opt.id)}
-              className={`flex w-full items-center justify-between rounded-xl border border-purple-200 bg-purple-50 p-4 transition-colors hover:bg-purple-100 ${
-                activeOptionId
-                  ? "cursor-not-allowed opacity-75"
-                  : "cursor-pointer"
-              } ${activeOptionId === opt.id ? "bg-purple-100" : ""}`}
-              disabled={Boolean(activeOptionId)}
-            >
-              <div className="flex items-center space-x-4">
-                <img
-                  src={opt.icon}
-                  alt={opt.label}
-                  className="h-[100px] w-auto"
-                />
-                <span className="text-purple-800 font-medium">{opt.label}</span>
-              </div>
-              <span className="text-purple-700">{opt.price}</span>
-            </button>
-          ))}
+          {OPTIONS.map((opt) => {
+            const shouldUseVkPrice = isVK && typeof opt.vkPrice === "number";
+            const priceValue = shouldUseVkPrice ? opt.vkPrice! : opt.price;
+            const formattedPrice = new Intl.NumberFormat("ru-RU").format(
+              priceValue
+            );
+
+            return (
+              <button
+                key={opt.id}
+                type="button"
+                onClick={() => handleOptionClick(opt.id)}
+                className={`flex w-full items-center justify-between rounded-xl border border-purple-200 bg-purple-50 p-4 transition-colors hover:bg-purple-100 ${
+                  activeOptionId
+                    ? "cursor-not-allowed opacity-75"
+                    : "cursor-pointer"
+                } ${activeOptionId === opt.id ? "bg-purple-100" : ""}`}
+                disabled={Boolean(activeOptionId)}
+              >
+                <div className="flex items-center space-x-4">
+                  <img
+                    src={opt.icon}
+                    alt={opt.label}
+                    className="h-[100px] w-auto"
+                  />
+                  <span className="text-purple-800 font-medium">{opt.label}</span>
+                </div>
+                <span className="inline-flex items-center gap-1 rounded-full bg-purple-100 px-3 py-1 text-purple-700 font-semibold">
+                  {formattedPrice}
+                  <img
+                    src={VK_PRICE_ICON_URL}
+                    alt="VK Pay"
+                    className="h-4 w-4"
+                  />
+                </span>
+              </button>
+            );
+          })}
         </div>
 
         <button

--- a/src/components/EnergyReplenishment.tsx
+++ b/src/components/EnergyReplenishment.tsx
@@ -121,7 +121,7 @@ const EnergyReplenishment: React.FC<EnergyReplenishmentProps> = ({
         </h2>
         <div className="space-y-4">
           {OPTIONS.map((opt) => {
-            const shouldUseVkPrice = isVK && typeof opt.vkPrice === "number";
+            const shouldUseVkPrice = isVK === true && typeof opt.vkPrice === "number";
             const priceValue = shouldUseVkPrice ? opt.vkPrice! : opt.price;
             const formattedPrice = new Intl.NumberFormat("ru-RU").format(
               priceValue
@@ -149,11 +149,15 @@ const EnergyReplenishment: React.FC<EnergyReplenishmentProps> = ({
                 </div>
                 <span className="inline-flex items-center gap-1 rounded-full bg-purple-100 px-3 py-1 text-purple-700 font-semibold">
                   {formattedPrice}
-                  <img
-                    src={VK_PRICE_ICON_URL}
-                    alt="VK Pay"
-                    className="h-4 w-4"
-                  />
+                  {shouldUseVkPrice ? (
+                    <img
+                      src={VK_PRICE_ICON_URL}
+                      alt="VK Pay"
+                      className="h-4 w-4"
+                    />
+                  ) : (
+                    <span>₽</span>
+                  )}
                 </span>
               </button>
             );

--- a/src/components/EnergySection.tsx
+++ b/src/components/EnergySection.tsx
@@ -7,12 +7,14 @@ interface EnergySectionProps {
   teachEnergy: number;
   timer: number;
   userId: number | null;
+  isVK?: boolean;
 }
 
 const EnergySection: React.FC<EnergySectionProps> = ({
   teachEnergy,
   timer,
   userId,
+  isVK = false,
 }) => {
   const [showEnergyModal, setShowEnergyModal] = useState(false);
   return (
@@ -43,6 +45,7 @@ const EnergySection: React.FC<EnergySectionProps> = ({
         <EnergyReplenishment
           onClose={() => setShowEnergyModal(false)}
           userId={userId}
+          isVK={isVK}
         />
       )}
     </div>

--- a/src/components/RaisingSection.tsx
+++ b/src/components/RaisingSection.tsx
@@ -42,6 +42,7 @@ interface RaisingSectionProps {
   teachEnergy: number;
   timer: number;
   userId: number | null;
+  isVK?: boolean;
   roomImage: string;
   monsterImage: string;
   roomItems: RoomItem[];
@@ -70,6 +71,7 @@ const RaisingSection: React.FC<RaisingSectionProps> = ({
   teachEnergy,
   timer,
   userId,
+  isVK = false,
   roomImage,
   monsterImage,
   roomItems,
@@ -262,6 +264,7 @@ const RaisingSection: React.FC<RaisingSectionProps> = ({
         <EnergyReplenishment
           onClose={() => setShowEnergyModal(false)}
           userId={userId}
+          isVK={isVK}
         />
       )}
     </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1035,6 +1035,7 @@ const App: React.FC = () => {
         <EnergyReplenishment
           onClose={() => setShowEnergyModal(false)}
           userId={userId}
+          isVK={isVKEnvironment}
         />
       )}
 


### PR DESCRIPTION
## Summary
- update the energy replenishment modal to select VK-specific badge prices and always render the VK currency icon
- thread the VK environment flag through energy-related sections so the replenishment modal can adjust its pricing dynamically

## Testing
- CI=true yarn test --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d4502ae39c832aa6a043a0b599c625