### PR TITLE
Adjust competition energy prices for VK environment

### DIFF
--- a/src/Arena.tsx
+++ b/src/Arena.tsx
@@ -8,9 +8,10 @@ import CompetitionHistory from "./components/CompetitionHistory";
 
 interface ArenaProps {
   userId: number | null;
+  isVK?: boolean;
 }
 
-const Arena: React.FC<ArenaProps> = ({ userId }) => {
+const Arena: React.FC<ArenaProps> = ({ userId, isVK = false }) => {
   const [selectedMonsterId, setSelectedMonsterId] = useState<number | null>(
     null
   );
@@ -57,7 +58,7 @@ const Arena: React.FC<ArenaProps> = ({ userId }) => {
         {/* На широких экранах: энергия и переключатель в одной строке */}
         <div className="hidden md:flex md:items-start md:justify-between md:gap-6">
           <div className="flex-shrink-0">
-            <CompetitionEnergy userId={userId} />
+            <CompetitionEnergy userId={userId} isVK={isVK} />
           </div>
           <div className="flex-1 min-w-0">
             <ArenaMonsterSwitcher
@@ -70,7 +71,7 @@ const Arena: React.FC<ArenaProps> = ({ userId }) => {
 
         {/* На узких экранах: энергия сверху, переключатель снизу */}
         <div className="md:hidden space-y-4">
-          <CompetitionEnergy userId={userId} />
+          <CompetitionEnergy userId={userId} isVK={isVK} />
           <ArenaMonsterSwitcher
             userId={userId}
             selectedMonsterId={selectedMonsterId}

--- a/src/components/CompetitionEnergy.tsx
+++ b/src/components/CompetitionEnergy.tsx
@@ -7,9 +7,10 @@ import CompetitionEnergyReplenishment from "./CompetitionEnergyReplenishment";
 
 interface Props {
   userId: number;
+  isVK?: boolean;
 }
 
-const CompetitionEnergy: React.FC<Props> = ({ userId }) => {
+const CompetitionEnergy: React.FC<Props> = ({ userId, isVK = false }) => {
   const [energy, setEnergy] = useState<number | null>(null);
   const [next, setNext] = useState<string>("");
   const [timer, setTimer] = useState<number>(0);
@@ -87,6 +88,7 @@ const CompetitionEnergy: React.FC<Props> = ({ userId }) => {
         <CompetitionEnergyReplenishment
           onClose={() => setShowReplenishment(false)}
           userId={userId}
+          isVK={isVK}
         />
       )}
     </>

--- a/src/components/CompetitionEnergyReplenishment.tsx
+++ b/src/components/CompetitionEnergyReplenishment.tsx
@@ -5,15 +5,20 @@ import React, { useEffect, useState } from "react";
 interface CompetitionEnergyReplenishmentProps {
   onClose: () => void;
   userId: number;
+  isVK?: boolean;
 }
 
 interface BadgeOption {
   id: string;
   label: string;
-  price: string;
+  price: number;
+  vkPrice?: number;
   icon: string;
   invoiceTypeId: number;
 }
+
+const VK_PRICE_ICON_URL =
+  "https://storage.yandexcloud.net/svm/img/service_icons/vk.png";
 
 interface CreatePaymentLinkResponse {
   paymentlink?: string | null;
@@ -24,14 +29,16 @@ const BADGES: BadgeOption[] = [
   {
     id: "ten",
     label: "Десять единиц энергии",
-    price: "270 ₽",
+    price: 270,
+    vkPrice: 39,
     icon: "https://storage.yandexcloud.net/svm/img/compenerjymid.png",
     invoiceTypeId: 9,
   },
   {
     id: "ninety",
     label: "Девяносто единиц энергии",
-    price: "1980 ₽",
+    price: 1980,
+    vkPrice: 283,
     icon: "https://storage.yandexcloud.net/svm/img/compenerjymany.png",
     invoiceTypeId: 10,
   },
@@ -40,6 +47,7 @@ const BADGES: BadgeOption[] = [
 const CompetitionEnergyReplenishment: React.FC<CompetitionEnergyReplenishmentProps> = ({
   onClose,
   userId,
+  isVK = false,
 }) => {
   const [dialogMessage, setDialogMessage] = useState<string | null>(null);
   const [activeBadgeId, setActiveBadgeId] = useState<string | null>(null);
@@ -147,6 +155,14 @@ const CompetitionEnergyReplenishment: React.FC<CompetitionEnergyReplenishmentPro
               {BADGES.map((badge) => {
                 const isDisabled = Boolean(activeBadgeId);
                 const isActive = activeBadgeId === badge.id;
+                const shouldUseVkPrice =
+                  isVK === true && typeof badge.vkPrice === "number";
+                const priceValue = shouldUseVkPrice
+                  ? badge.vkPrice!
+                  : badge.price;
+                const formattedPrice = new Intl.NumberFormat("ru-RU").format(
+                  priceValue
+                );
 
                 return (
                   <button
@@ -177,8 +193,17 @@ const CompetitionEnergyReplenishment: React.FC<CompetitionEnergyReplenishmentPro
                         <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
                           Цена
                         </span>
-                        <span className="text-2xl font-bold text-purple-300 md:text-3xl">
-                          {badge.price}
+                        <span className="text-2xl font-bold text-purple-300 md:text-3xl inline-flex items-center gap-2">
+                          {formattedPrice}
+                          {shouldUseVkPrice ? (
+                            <img
+                              src={VK_PRICE_ICON_URL}
+                              alt="VK Pay"
+                              className="h-5 w-5"
+                            />
+                          ) : (
+                            <span>₽</span>
+                          )}
                         </span>
                       </div>
                     </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1004,7 +1004,7 @@ const App: React.FC = () => {
       {/* Остальные разделы */}
       {!showRaisingInteraction &&
         selectedMenuSequence === MENU_SEQUENCES.ARENA && (
-          <Arena userId={userId} />
+          <Arena userId={userId} isVK={isVKEnvironment} />
         )}
       {!showRaisingInteraction &&
         selectedMenuSequence === MENU_SEQUENCES.SHOP && (


### PR DESCRIPTION
## Summary
- allow the competition energy replenishment modal to render VK-specific badge prices and show the VK payment icon
- propagate the VK environment flag through the arena energy components so the modal can detect VK usage

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d454cd5204832a9b34994c1567ce8c