### PR TITLE
Ensure payment modals stay in view

### DIFF
--- a/src/components/CompetitionEnergyReplenishment.tsx
+++ b/src/components/CompetitionEnergyReplenishment.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import bridge from "@vkontakte/vk-bridge";
 
 
@@ -59,6 +59,8 @@ const CompetitionEnergyReplenishment: React.FC<CompetitionEnergyReplenishmentPro
     | null
   >(null);
   const [activeBadgeId, setActiveBadgeId] = useState<string | null>(null);
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const restartTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
     const { overflow } = document.body.style;
@@ -67,6 +69,24 @@ const CompetitionEnergyReplenishment: React.FC<CompetitionEnergyReplenishmentPro
     return () => {
       document.body.style.overflow = overflow;
     };
+  }, []);
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+    modalRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+
+    return () => {
+      if (restartTimeoutRef.current !== null) {
+        window.clearTimeout(restartTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleRestart = useCallback(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+    restartTimeoutRef.current = window.setTimeout(() => {
+      window.location.reload();
+    }, 300);
   }, []);
 
   const handleBadgeClick = async (badgeId: string) => {
@@ -220,9 +240,12 @@ const CompetitionEnergyReplenishment: React.FC<CompetitionEnergyReplenishmentPro
   };
 
   return (
-    <div className="fixed inset-0 z-[200] overflow-y-auto bg-black/70">
-      <div className="flex min-h-full items-start justify-center px-4 py-10 md:items-center md:py-16">
-        <div className="relative w-full max-w-4xl rounded-3xl bg-gradient-to-br from-slate-950 via-slate-900 to-black p-6 text-white shadow-[0_25px_80px_rgba(0,0,0,0.55)] max-h-[calc(100vh-4rem)] overflow-y-auto md:p-8">
+    <div className="fixed inset-0 z-[200] flex items-start justify-center overflow-y-auto bg-black/70 px-4 py-6">
+      <div className="flex min-h-full w-full max-w-4xl justify-center">
+        <div
+          className="relative w-full rounded-3xl bg-gradient-to-br from-slate-950 via-slate-900 to-black p-6 text-white shadow-[0_25px_80px_rgba(0,0,0,0.55)] max-h-[calc(100vh-4rem)] overflow-y-auto md:p-8"
+          ref={modalRef}
+        >
           <button
             type="button"
             aria-label="Закрыть окно пополнения энергии"
@@ -327,7 +350,7 @@ const CompetitionEnergyReplenishment: React.FC<CompetitionEnergyReplenishmentPro
             {dialogConfig.variant === "success" ? (
               <button
                 type="button"
-                onClick={() => window.location.reload()}
+                onClick={handleRestart}
                 className="mt-6 w-full rounded-full bg-purple-600 px-4 py-2 text-sm font-semibold uppercase tracking-wider text-white transition-colors hover:bg-purple-500"
               >
                 Перезапустить игру

--- a/src/components/EnergyReplenishment.tsx
+++ b/src/components/EnergyReplenishment.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import bridge from "@vkontakte/vk-bridge";
 
 interface EnergyReplenishmentProps {
@@ -57,6 +57,26 @@ const EnergyReplenishment: React.FC<EnergyReplenishmentProps> = ({
     | null
   >(null);
   const [activeOptionId, setActiveOptionId] = useState<string | null>(null);
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const restartTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+    modalRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+
+    return () => {
+      if (restartTimeoutRef.current !== null) {
+        window.clearTimeout(restartTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleRestart = useCallback(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+    restartTimeoutRef.current = window.setTimeout(() => {
+      window.location.reload();
+    }, 300);
+  }, []);
 
   const handleOptionClick = async (optionId: string) => {
     if (!userId) {
@@ -213,8 +233,11 @@ const EnergyReplenishment: React.FC<EnergyReplenishmentProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center z-[150] bg-black/60">
-      <div className="bg-gradient-to-br from-purple-50 to-orange-50 rounded-2xl p-6 shadow-2xl w-full max-w-md space-y-6">
+    <div className="fixed inset-0 z-[150] flex items-start justify-center overflow-y-auto bg-black/60 px-4 py-6">
+      <div
+        className="bg-gradient-to-br from-purple-50 to-orange-50 rounded-2xl p-6 shadow-2xl w-full max-w-md space-y-6"
+        ref={modalRef}
+      >
         <h2 className="text-2xl font-bold text-purple-700 text-center">
           Пополнение энергии
         </h2>
@@ -271,13 +294,13 @@ const EnergyReplenishment: React.FC<EnergyReplenishmentProps> = ({
         </button>
       </div>
       {dialogConfig && (
-        <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60">
+        <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 px-4">
           <div className="bg-white rounded-xl shadow-2xl p-6 max-w-sm w-full text-center space-y-4">
             <div className="text-purple-700 font-semibold">{dialogConfig.message}</div>
             {dialogConfig.variant === "success" ? (
               <button
                 type="button"
-                onClick={() => window.location.reload()}
+                onClick={handleRestart}
                 className="w-full bg-purple-500 hover:bg-purple-600 text-white py-2 rounded-lg"
               >
                 Перезапустить игру

--- a/src/components/MonsterTypeSelector.tsx
+++ b/src/components/MonsterTypeSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import bridge from "@vkontakte/vk-bridge";
 import { MonsterTypeInfo } from "../types";
 
@@ -37,8 +37,28 @@ const MonsterTypeSelector: React.FC<MonsterTypeSelectorProps> = ({
 }) => {
   const [processingId, setProcessingId] = useState<number | null>(null);
   const [dialogConfig, setDialogConfig] = useState<DialogConfig | null>(null);
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const restartTimeoutRef = useRef<number | null>(null);
 
   const isProcessing = processingId !== null;
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+    modalRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+
+    return () => {
+      if (restartTimeoutRef.current !== null) {
+        window.clearTimeout(restartTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleRestart = useCallback(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+    restartTimeoutRef.current = window.setTimeout(() => {
+      window.location.reload();
+    }, 300);
+  }, []);
 
   const handleTypeSelection = async (type: MonsterTypeInfo) => {
     if (!type.activity || isProcessing) {
@@ -198,7 +218,7 @@ const MonsterTypeSelector: React.FC<MonsterTypeSelectorProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-6">
+    <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/40 px-4 py-6">
       <div
         className="relative w-full max-w-4xl max-h-[90vh] overflow-hidden rounded-3xl bg-gradient-to-br from-white via-purple-50 to-orange-50 shadow-[0_25px_70px_-35px_rgba(109,40,217,0.7)]"
         id="monster-type-selector"
@@ -206,6 +226,7 @@ const MonsterTypeSelector: React.FC<MonsterTypeSelectorProps> = ({
         aria-modal="true"
         aria-labelledby="monster-type-selector-title"
         aria-describedby="monster-type-selector-description"
+        ref={modalRef}
       >
         <button
           type="button"
@@ -369,7 +390,7 @@ const MonsterTypeSelector: React.FC<MonsterTypeSelectorProps> = ({
               {dialogConfig.variant === "success" ? (
                 <button
                   type="button"
-                  onClick={() => window.location.reload()}
+                  onClick={handleRestart}
                   className="mt-6 inline-flex items-center justify-center rounded-xl bg-gradient-to-r from-purple-500 to-orange-400 px-6 py-2 text-sm font-semibold text-white shadow transition hover:from-purple-600 hover:to-orange-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-purple-500"
                 >
                   Перезапустить игру


### PR DESCRIPTION
## Summary
- ensure the monster selection and energy replenishment modals scroll into view when opened
- scroll the viewport to the top before reloading after a successful VK order

## Testing
- yarn test --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d48f5a68fc832a9759b51143337b1b