### PR TITLE
Handle missing monster id during initial bootstrap

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -526,18 +526,20 @@ const App: React.FC = () => {
         setNotificationCount(notificationRes.notificationquantity);
 
         // Монстры
-        const sorted = (monstersRes.monsters || []).sort(
+        const sorted = [...(monstersRes.monsters || [])].sort(
           (a, b) => a.sequence - b.sequence
         );
         setMonsters(sorted);
 
         // Выбор монстра
-        const defaultMonster = sorted.find((m) => m.index);
+        const defaultMonsterIndex = sorted.findIndex((m) => m.index);
         let selectedMonsterLocal: number | null = null;
-        if (defaultMonster) {
-          selectedMonsterLocal = (defaultMonster as any).monsterId;
+        if (defaultMonsterIndex >= 0) {
+          selectedMonsterLocal = initRes.monstersId[defaultMonsterIndex] ?? null;
+        } else if (initRes.monstersId.length > 0) {
+          selectedMonsterLocal = initRes.monstersId[0];
         } else if (sorted.length > 0) {
-          selectedMonsterLocal = (sorted[0] as any).monsterId;
+          selectedMonsterLocal = (sorted[0] as any).monsterId ?? null;
         }
 
         // Сохраняем начальный ID монстра


### PR DESCRIPTION
## Summary
- ensure the bootstrap flow copies the monsters array before sorting
- derive the initially selected monster from the init response when explicit monster ids are missing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d65fec167c832ab1f35ff5f3f5de4a