### PR TITLE
Add VK ad checks and interstitial display on raising interaction exit

### DIFF
--- a/src/RaisingInteraction.tsx
+++ b/src/RaisingInteraction.tsx
@@ -84,19 +84,26 @@ const RaisingInteraction: React.FC<RaisingInteractionProps> = ({
     itemBonuses,
   ]);
 
-  const handleClose = useCallback(async () => {
+  const handleClose = useCallback(() => {
     if (isVKEnvironment) {
       const vkBridge = (window as Window & { vkBridge?: VKBridgeInstance })
         .vkBridge;
 
       if (vkBridge) {
-        try {
-          await vkBridge.send("VKWebAppShowNativeAds", {
+        vkBridge
+          .send("VKWebAppShowNativeAds", {
             ad_format: "interstitial",
+          })
+          .then((result) => {
+            console.log("VKWebAppShowNativeAds result:", result);
+          })
+          .catch((error) => {
+            console.error("VKWebAppShowNativeAds error:", error);
           });
-        } catch (error) {
-          console.error("VKWebAppShowNativeAds error:", error);
-        }
+      } else {
+        console.warn(
+          "VK Bridge is not available; unable to request VKWebAppShowNativeAds"
+        );
       }
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -188,12 +188,18 @@ const App: React.FC = () => {
       .vkBridge;
 
     if (!vkBridge) {
+      console.warn(
+        "VK Bridge is not available; skipping VKWebAppCheckNativeAds calls"
+      );
       return;
     }
 
     const checkAds = () => {
       vkBridge
         .send("VKWebAppCheckNativeAds", { ad_format: "interstitial" })
+        .then((result) => {
+          console.log("VKWebAppCheckNativeAds result:", result);
+        })
         .catch((error) =>
           console.error("VKWebAppCheckNativeAds error:", error)
         );


### PR DESCRIPTION
## Summary
- add a periodic VKWebAppCheckNativeAds call when the app detects the VK environment
- request an interstitial ad before closing the Raising Interaction screen in VK

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6b34054e8832aad22199eecb1ad5e