### PR TITLE
feat: add VK desktop layouts

### DIFF
--- a/src/Arena.tsx
+++ b/src/Arena.tsx
@@ -5,13 +5,19 @@ import ArenaMonsterSwitcher from "./components/ArenaMonsterSwitcher";
 import Competitions from "./components/Competitions";
 import CurrentCompetition from "./components/CurrentCompetition";
 import CompetitionHistory from "./components/CompetitionHistory";
+import VKDesktopFrame from "./components/VKDesktopFrame";
 
 interface ArenaProps {
   userId: number | null;
   isVK?: boolean;
+  isVKDesktop?: boolean;
 }
 
-const Arena: React.FC<ArenaProps> = ({ userId, isVK = false }) => {
+const Arena: React.FC<ArenaProps> = ({
+  userId,
+  isVK = false,
+  isVKDesktop = false,
+}) => {
   const [selectedMonsterId, setSelectedMonsterId] = useState<number | null>(
     null
   );
@@ -48,7 +54,55 @@ const Arena: React.FC<ArenaProps> = ({ userId, isVK = false }) => {
   if (!userId) return null;
 
   if (currentCompetitionId) {
-    return <CurrentCompetition competitionsInstanceId={currentCompetitionId} />;
+    return (
+      <CurrentCompetition
+        competitionsInstanceId={currentCompetitionId}
+        isVKDesktop={isVKDesktop}
+      />
+    );
+  }
+
+  if (isVKDesktop) {
+    return (
+      <VKDesktopFrame title="Арена" contentClassName="flex flex-col" accent="purple">
+        <div className="flex flex-col h-full space-y-8">
+          <div className="grid grid-cols-[320px,1fr] gap-6">
+            <div className="space-y-6">
+              <div className="rounded-3xl border border-blue-200 bg-white/90 p-6 shadow-inner">
+                <CompetitionEnergy
+                  userId={userId}
+                  isVK={isVK}
+                  isVKDesktop={isVKDesktop}
+                />
+              </div>
+              {historyEnabled && (
+                <div className="rounded-3xl border border-orange-200 bg-white/90 p-6 shadow-inner">
+                  <CompetitionHistory />
+                </div>
+              )}
+            </div>
+            <div className="rounded-3xl border border-emerald-200 bg-white/90 p-6 shadow-inner">
+              <ArenaMonsterSwitcher
+                userId={userId}
+                selectedMonsterId={selectedMonsterId}
+                onMonsterChange={handleMonsterChange}
+              />
+            </div>
+          </div>
+
+          <div className="flex-1 rounded-3xl border-2 border-orange-200 bg-white/95 p-6 shadow-xl">
+            <h2 className="text-3xl font-bold text-orange-700 text-center mb-6">
+              Состязания
+            </h2>
+            <Competitions
+              selectedMonsterId={selectedMonsterId}
+              userId={userId}
+              onCompetitionStart={handleCompetitionStart}
+            />
+          </div>
+        </div>
+      </VKDesktopFrame>
+    );
   }
 
   return (

--- a/src/Inventory.tsx
+++ b/src/Inventory.tsx
@@ -1,6 +1,7 @@
 // Inventory.tsx — компонент "Инвентарь" с фреймами "Предметы пользователя" и "Предметы монстров"
 import React, { useState, useEffect, useCallback } from "react";
 import axios from "axios";
+import VKDesktopFrame from "./components/VKDesktopFrame";
 
 // Импорт компонента MonsterItems
 const MonsterItems = React.lazy(() => import("./MonsterItems"));
@@ -34,6 +35,7 @@ interface UserItemsResponse {
 
 interface InventoryProps {
   userId: number | null;
+  isVKDesktop?: boolean;
 }
 
 // ===== Функция с бесконечными повторами при таймауте =====
@@ -101,7 +103,10 @@ async function withRetry<T>(
 }
 
 // ===== Основной компонент =====
-const Inventory: React.FC<InventoryProps> = ({ userId }) => {
+const Inventory: React.FC<InventoryProps> = ({
+  userId,
+  isVKDesktop = false,
+}) => {
   const [items, setItems] = useState<UserInventoryItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>("");
@@ -245,243 +250,294 @@ const Inventory: React.FC<InventoryProps> = ({ userId }) => {
     }
   };
 
-  // ===== Рендер =====
-  return (
-    <div className="p-6">
-      {/* Спиннер загрузки */}
-      {loading && (
-        <div className="w-full flex items-center justify-center py-16">
-          <div className="w-12 h-12 border-4 border-purple-500 border-t-transparent rounded-full animate-spin" />
-        </div>
-      )}
+  const isDesktopView = isVKDesktop;
 
-      {!loading && (
-        <div className="max-w-6xl mx-auto">
-          {/* Ошибка */}
-          {error && (
-            <div className="bg-red-100 text-red-700 border border-red-300 px-4 py-3 rounded-lg mb-6">
-              {error}
-            </div>
-          )}
+  const renderContent = () => {
+    const loadingWrapperClass = isDesktopView
+      ? "w-full flex items-center justify-center py-20"
+      : "w-full flex items-center justify-center py-16";
+    const contentWrapperClass = isDesktopView
+      ? "mx-auto max-w-6xl space-y-10"
+      : "max-w-6xl mx-auto";
+    const errorAlertClass = isDesktopView
+      ? "bg-red-100 text-red-700 border border-red-300 px-6 py-4 rounded-3xl shadow mb-6"
+      : "bg-red-100 text-red-700 border border-red-300 px-4 py-3 rounded-lg mb-6";
+    const userItemsFrameClass = isDesktopView
+      ? "bg-gradient-to-br from-purple-50 to-orange-50 rounded-3xl shadow-xl border border-purple-200 p-8"
+      : "bg-gradient-to-br from-purple-50 to-orange-50 rounded-xl shadow-lg border border-purple-200 p-6";
+    const userItemsTitleClass = isDesktopView
+      ? "text-3xl font-bold text-purple-800 mb-6 text-center"
+      : "text-2xl font-bold text-purple-800 mb-6 text-center";
+    const emptyStateWrapperClass = isDesktopView
+      ? "text-center py-16"
+      : "text-center py-12";
+    const emptyEmojiClass = isDesktopView
+      ? "text-purple-400 text-5xl mb-6"
+      : "text-purple-400 text-4xl mb-4";
+    const emptyTitleClass = isDesktopView
+      ? "text-purple-700 text-xl font-semibold mb-2"
+      : "text-purple-700 text-lg font-medium mb-2";
+    const emptyDescriptionClass = "text-purple-600 text-sm";
+    const itemsGridClass = isDesktopView
+      ? "flex flex-wrap justify-center gap-8"
+      : "flex flex-wrap justify-center gap-6";
+    const itemCardBase = isDesktopView
+      ? "border-2 rounded-3xl p-6 shadow-xl transition-all duration-200 w-72 min-h-[320px]"
+      : "border-2 rounded-xl p-4 shadow-md transition-all duration-200 w-64 min-h-[280px]";
+    const itemImageWrapperClass = isDesktopView
+      ? "flex justify-center mb-4"
+      : "flex justify-center mb-3";
+    const itemImageClass = isDesktopView
+      ? "w-20 h-20 object-contain"
+      : "w-16 h-16 object-contain";
+    const itemNameClass = isDesktopView
+      ? "text-base font-bold text-gray-800 text-center mb-2 leading-tight"
+      : "text-sm font-bold text-gray-800 text-center mb-2 leading-tight";
+    const itemDescriptionClass = isDesktopView
+      ? "text-sm text-gray-600 text-center leading-relaxed"
+      : "text-xs text-gray-600 text-center leading-relaxed";
+    const indicatorWrapperClass = isDesktopView
+      ? "flex justify-center mt-4"
+      : "flex justify-center mt-3";
+    const dropdownContainerClass = isDesktopView
+      ? "absolute top-full left-0 right-0 mt-3 bg-white rounded-2xl shadow-2xl border border-gray-200 z-50 overflow-hidden"
+      : "absolute top-full left-0 right-0 mt-2 bg-white rounded-lg shadow-xl border border-gray-200 z-50 overflow-hidden";
+    const dropdownButtonClass = isDesktopView
+      ? "w-full flex items-center gap-4 px-5 py-4 text-left hover:bg-gray-50 transition-colors duration-150 border-b border-gray-100 last:border-b-0"
+      : "w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-150 border-b border-gray-100 last:border-b-0";
+    const dropdownIconClass = isDesktopView
+      ? "w-7 h-7 object-contain flex-shrink-0"
+      : "w-6 h-6 object-contain flex-shrink-0";
+    const dropdownSpinnerClass = isDesktopView
+      ? "w-5 h-5 border-2 border-purple-500 border-t-transparent rounded-full animate-spin flex-shrink-0"
+      : "w-4 h-4 border-2 border-purple-500 border-t-transparent rounded-full animate-spin flex-shrink-0";
+    const actionOverlayClass = isDesktopView
+      ? "absolute inset-0 bg-white bg-opacity-90 flex items-center justify-center rounded-3xl z-60"
+      : "absolute inset-0 bg-white bg-opacity-90 flex items-center justify-center rounded-xl z-60";
+    const actionSpinnerClass = isDesktopView
+      ? "w-9 h-9 border-4 border-purple-500 border-t-transparent rounded-full animate-spin"
+      : "w-8 h-8 border-4 border-purple-500 border-t-transparent rounded-full animate-spin";
+    const monsterFallbackClass = isDesktopView
+      ? "w-full flex items-center justify-center py-20"
+      : "w-full flex items-center justify-center py-16";
+    const modalContainerClass = isDesktopView
+      ? "bg-white rounded-2xl shadow-2xl p-8 max-w-lg w-full mx-4"
+      : "bg-white rounded-xl shadow-xl p-6 max-w-md w-full mx-4";
+    const modalTitleClass = isDesktopView
+      ? "text-xl font-semibold mb-4 text-gray-800"
+      : "text-lg font-semibold mb-4 text-gray-800";
+    const modalTextClass = isDesktopView
+      ? "text-gray-700 whitespace-pre-wrap mb-6 text-base"
+      : "text-gray-700 whitespace-pre-wrap mb-6";
+    const modalButtonClass = isDesktopView
+      ? "px-8 py-3 bg-purple-500 text-white rounded-xl hover:bg-purple-600 transition-colors duration-200"
+      : "px-6 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 transition-colors duration-200";
 
-          {/* Фрейм "Предметы пользователя" */}
-          <div className="bg-gradient-to-br from-purple-50 to-orange-50 rounded-xl shadow-lg border border-purple-200 p-6">
-            <h2 className="text-2xl font-bold text-purple-800 mb-6 text-center">
-              Предметы пользователя
-            </h2>
+    return (
+      <>
+        {loading && (
+          <div className={loadingWrapperClass}>
+            <div className="w-12 h-12 border-4 border-purple-500 border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
 
-            {/* Сообщение об отсутствии предметов */}
-            {!error && items.length === 0 && (
-              <div className="text-center py-12">
-                <div className="text-purple-400 text-4xl mb-4">📦</div>
-                <div className="text-purple-700 text-lg font-medium mb-2">
-                  У вас еще нет предметов
+        {!loading && (
+          <div className={contentWrapperClass}>
+            {error && <div className={errorAlertClass}>{error}</div>}
+
+            <div className={userItemsFrameClass}>
+              <h2 className={userItemsTitleClass}>Предметы пользователя</h2>
+
+              {!error && items.length === 0 && (
+                <div className={emptyStateWrapperClass}>
+                  <div className={emptyEmojiClass}>📦</div>
+                  <div className={emptyTitleClass}>У вас еще нет предметов</div>
+                  <div className={emptyDescriptionClass}>
+                    Получайте предметы через взаимодействия с монстрами или
+                    покупайте в магазине
+                  </div>
                 </div>
-                <div className="text-purple-600 text-sm">
-                  Получайте предметы через взаимодействия с монстрами или
-                  покупайте в магазине
-                </div>
-              </div>
-            )}
+              )}
 
-            {/* Сетка предметов с идеальным центрированием */}
-            {items.length > 0 && (
-              <div className="flex flex-wrap justify-center gap-6">
-                {items.map((userItem) => {
-                  const item = userItem.inventoryitem;
-                  const isClickable = item.activity;
-                  const isDropdownOpen = selectedItem === item.inventoryid;
+              {items.length > 0 && (
+                <div className={itemsGridClass}>
+                  {items.map((userItem) => {
+                    const item = userItem.inventoryitem;
+                    const isClickable = item.activity;
+                    const isDropdownOpen = selectedItem === item.inventoryid;
+                    const cardClasses = `${getBadgeStyle(item.inventorytype)} ${itemCardBase} ${
+                      isClickable
+                        ? "cursor-pointer hover:shadow-2xl hover:-translate-y-1 active:scale-95"
+                        : "opacity-60 cursor-not-allowed"
+                    } ${isDropdownOpen ? "ring-2 ring-purple-500" : ""}`;
 
-                  return (
-                    <div key={item.inventoryid} className="relative">
-                      {/* Основной бейдж предмета */}
-                      <div
-                        className={`
-                          ${getBadgeStyle(item.inventorytype)}
-                          border-2 rounded-xl p-4 shadow-md transition-all duration-200 w-64 min-h-[280px]
-                          ${
-                            isClickable
-                              ? "cursor-pointer hover:shadow-lg hover:scale-105 active:scale-95"
-                              : "opacity-60 cursor-not-allowed"
-                          }
-                          ${isDropdownOpen ? "ring-2 ring-purple-500" : ""}
-                        `}
-                        onClick={() => {
-                          if (isClickable && item.itemactions.length > 0) {
-                            setSelectedItem(
-                              isDropdownOpen ? null : item.inventoryid
-                            );
-                          }
-                        }}
-                      >
-                        {/* Количество предметов (бейдж в углу) */}
-                        {parseInt(item.quantity) > 1 && (
-                          <div className="absolute -top-2 -right-2 bg-orange-500 text-white text-sm font-bold px-2 py-1 rounded-full shadow-md border-2 border-white">
-                            {item.quantity}
-                          </div>
-                        )}
-
-                        {/* Изображение предмета */}
-                        <div className="flex justify-center mb-3">
-                          <img
-                            src={item.inventoryimage}
-                            alt={item.inventoryname}
-                            className="w-16 h-16 object-contain"
-                            onError={(e) => {
-                              console.error(
-                                `Ошибка загрузки изображения: ${item.inventoryimage}`
+                    return (
+                      <div key={item.inventoryid} className="relative">
+                        <div
+                          className={cardClasses}
+                          onClick={() => {
+                            if (isClickable && item.itemactions.length > 0) {
+                              setSelectedItem(
+                                isDropdownOpen ? null : item.inventoryid
                               );
-                              e.currentTarget.src = "/placeholder-item.png";
-                            }}
-                          />
+                            }
+                          }}
+                        >
+                          {parseInt(item.quantity) > 1 && (
+                            <div className="absolute -top-2 -right-2 bg-orange-500 text-white text-sm font-bold px-2 py-1 rounded-full shadow-md border-2 border-white">
+                              {item.quantity}
+                            </div>
+                          )}
+
+                          <div className={itemImageWrapperClass}>
+                            <img
+                              src={item.inventoryimage}
+                              alt={item.inventoryname}
+                              className={itemImageClass}
+                              onError={(e) => {
+                                console.error(
+                                  `Ошибка загрузки изображения: ${item.inventoryimage}`
+                                );
+                                e.currentTarget.src = "/placeholder-item.png";
+                              }}
+                            />
+                          </div>
+
+                          <h3 className={itemNameClass}>{item.inventoryname}</h3>
+
+                          <p className={itemDescriptionClass}>
+                            {item.inventorydescription}
+                          </p>
+
+                          {isClickable && item.itemactions.length > 0 && (
+                            <div className={indicatorWrapperClass}>
+                              <div className="flex space-x-1">
+                                <div className="w-1.5 h-1.5 bg-purple-500 rounded-full animate-pulse"></div>
+                                <div
+                                  className="w-1.5 h-1.5 bg-purple-400 rounded-full animate-pulse"
+                                  style={{ animationDelay: "0.2s" }}
+                                ></div>
+                                <div
+                                  className="w-1.5 h-1.5 bg-purple-300 rounded-full animate-pulse"
+                                  style={{ animationDelay: "0.4s" }}
+                                ></div>
+                              </div>
+                            </div>
+                          )}
                         </div>
 
-                        {/* Название предмета */}
-                        <h3 className="text-sm font-bold text-gray-800 text-center mb-2 leading-tight">
-                          {item.inventoryname}
-                        </h3>
+                        {isDropdownOpen && item.itemactions.length > 0 && (
+                          <>
+                            <div
+                              className="fixed inset-0 bg-black bg-opacity-25 z-40"
+                              onClick={() => setSelectedItem(null)}
+                            />
 
-                        {/* Описание предмета */}
-                        <p className="text-xs text-gray-600 text-center leading-relaxed">
-                          {item.inventorydescription}
-                        </p>
-
-                        {/* Индикатор доступности действий */}
-                        {isClickable && item.itemactions.length > 0 && (
-                          <div className="flex justify-center mt-3">
-                            <div className="flex space-x-1">
-                              <div className="w-1.5 h-1.5 bg-purple-500 rounded-full animate-pulse"></div>
-                              <div
-                                className="w-1.5 h-1.5 bg-purple-400 rounded-full animate-pulse"
-                                style={{ animationDelay: "0.2s" }}
-                              ></div>
-                              <div
-                                className="w-1.5 h-1.5 bg-purple-300 rounded-full animate-pulse"
-                                style={{ animationDelay: "0.4s" }}
-                              ></div>
+                            <div className={dropdownContainerClass}>
+                              {item.itemactions.map((action, index) => (
+                                <button
+                                  key={index}
+                                  className={`${dropdownButtonClass} ${
+                                    actionLoading === action.actionname
+                                      ? "bg-gray-50 cursor-not-allowed"
+                                      : ""
+                                  }`}
+                                  onClick={() => handleItemAction(action)}
+                                  disabled={actionLoading === action.actionname}
+                                >
+                                  <img
+                                    src={action.actionicon}
+                                    alt=""
+                                    className={dropdownIconClass}
+                                  />
+                                  <span className="text-sm text-gray-700 flex-grow">
+                                    {action.actionname}
+                                  </span>
+                                  {actionLoading === action.actionname && (
+                                    <div className={dropdownSpinnerClass} />
+                                  )}
+                                </button>
+                              ))}
                             </div>
-                          </div>
+                          </>
                         )}
-                      </div>
 
-                      {/* Выпадающий список действий */}
-                      {isDropdownOpen && item.itemactions.length > 0 && (
-                        <>
-                          {/* Затемнение фона */}
-                          <div
-                            className="fixed inset-0 bg-black bg-opacity-25 z-40"
-                            onClick={() => setSelectedItem(null)}
-                          />
-
-                          {/* Выпадающий список */}
-                          <div className="absolute top-full left-0 right-0 mt-2 bg-white rounded-lg shadow-xl border border-gray-200 z-50 overflow-hidden">
-                            {item.itemactions.map((action, index) => (
-                              <button
-                                key={index}
-                                className={`w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-150 border-b border-gray-100 last:border-b-0 ${
-                                  actionLoading === action.actionname
-                                    ? "bg-gray-50 cursor-not-allowed"
-                                    : ""
-                                }`}
-                                onClick={() => handleItemAction(action)}
-                                disabled={actionLoading === action.actionname}
-                              >
-                                {/* Иконка действия */}
-                                <img
-                                  src={action.actionicon}
-                                  alt=""
-                                  className="w-6 h-6 object-contain flex-shrink-0"
-                                />
-
-                                {/* Текст действия */}
-                                <span className="text-sm text-gray-700 flex-grow">
-                                  {action.actionname}
+                        {actionLoading &&
+                          item.itemactions.some(
+                            (action) => action.actionname === actionLoading
+                          ) && (
+                            <div className={actionOverlayClass}>
+                              <div className="flex flex-col items-center gap-2">
+                                <div className={actionSpinnerClass} />
+                                <span className="text-sm text-purple-600 font-medium">
+                                  Выполняется...
                                 </span>
-
-                                {/* Спиннер для загружающегося действия */}
-                                {actionLoading === action.actionname && (
-                                  <div className="w-4 h-4 border-2 border-purple-500 border-t-transparent rounded-full animate-spin flex-shrink-0" />
-                                )}
-                              </button>
-                            ))}
-                          </div>
-                        </>
-                      )}
-
-                      {/* Глобальный спиннер поверх карточки при выполнении действия */}
-                      {actionLoading &&
-                        item.itemactions.some(
-                          (action) => action.actionname === actionLoading
-                        ) && (
-                          <div className="absolute inset-0 bg-white bg-opacity-90 flex items-center justify-center rounded-xl z-60">
-                            <div className="flex flex-col items-center gap-2">
-                              <div className="w-8 h-8 border-4 border-purple-500 border-t-transparent rounded-full animate-spin" />
-                              <span className="text-sm text-purple-600 font-medium">
-                                Выполняется...
-                              </span>
+                              </div>
                             </div>
-                          </div>
-                        )}
-                    </div>
-                  );
-                })}
-              </div>
-            )}
+                          )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <React.Suspense
+              fallback={
+                <div className={monsterFallbackClass}>
+                  <div className="w-12 h-12 border-4 border-emerald-500 border-t-transparent rounded-full animate-spin" />
+                </div>
+              }
+            >
+              <MonsterItems
+                userId={userId}
+                onRefreshAllFrames={refreshAllFrames}
+              />
+            </React.Suspense>
           </div>
+        )}
 
-          {/* Фрейм "Предметы монстров" */}
-          <React.Suspense
-            fallback={
-              <div className="w-full flex items-center justify-center py-16">
-                <div className="w-12 h-12 border-4 border-emerald-500 border-t-transparent rounded-full animate-spin" />
-              </div>
-            }
-          >
-            <MonsterItems
-              userId={userId}
-              onRefreshAllFrames={refreshAllFrames}
-            />
-          </React.Suspense>
-        </div>
-      )}
-
-      {/* Модальное окно с сообщением о результате действия */}
-      {showModal && (
-        <div
-          className="fixed inset-0 flex items-center justify-center z-50 bg-black bg-opacity-50"
-          onClick={() => {
-            setShowModal(false);
-            // Обновляем все фреймы при закрытии по клику вне модального окна
-            refreshAllFrames();
-          }}
-        >
+        {showModal && (
           <div
-            className="bg-white rounded-xl shadow-xl p-6 max-w-md w-full mx-4"
-            onClick={(e) => e.stopPropagation()}
+            className="fixed inset-0 flex items-center justify-center z-50 bg-black bg-opacity-50"
+            onClick={() => {
+              setShowModal(false);
+              refreshAllFrames();
+            }}
           >
-            <div className="text-lg font-semibold mb-4 text-gray-800">
-              Результат
-            </div>
-            <div className="text-gray-700 whitespace-pre-wrap mb-6">
-              {actionMessage}
-            </div>
-            <div className="flex justify-end">
-              <button
-                onClick={() => {
-                  setShowModal(false);
-                  // Обновляем все фреймы после закрытия модального окна
-                  refreshAllFrames();
-                }}
-                className="px-6 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 transition-colors duration-200"
-              >
-                OK
-              </button>
+            <div
+              className={modalContainerClass}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className={modalTitleClass}>Результат</div>
+              <div className={modalTextClass}>{actionMessage}</div>
+              <div className="flex justify-end">
+                <button
+                  onClick={() => {
+                    setShowModal(false);
+                    refreshAllFrames();
+                  }}
+                  className={modalButtonClass}
+                >
+                  OK
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-      )}
-    </div>
-  );
+        )}
+      </>
+    );
+  };
+
+  if (isDesktopView) {
+    return (
+      <VKDesktopFrame title="Инвентарь" accent="emerald">
+        {renderContent()}
+      </VKDesktopFrame>
+    );
+  }
+
+  return <div className="p-6">{renderContent()}</div>;
 };
 
 export default Inventory;

--- a/src/Shop.tsx
+++ b/src/Shop.tsx
@@ -2,11 +2,13 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import CoinPackSelector from "./components/CoinPackSelector";
+import VKDesktopFrame from "./components/VKDesktopFrame";
 
 // ===== Типы =====
 type Props = {
   userId: number | null; // берётся из init
   isVKEnvironment?: boolean;
+  isVKDesktop?: boolean;
 };
 
 type WalletResponse = {
@@ -55,7 +57,11 @@ async function withRetry<T>(
 
 // ===== Компонент =====
 
-const Shop: React.FC<Props> = ({ userId, isVKEnvironment = false }) => {
+const Shop: React.FC<Props> = ({
+  userId,
+  isVKEnvironment = false,
+  isVKDesktop = false,
+}) => {
   // --- Кошелёк ---
   const [money, setMoney] = useState<number>(0);
   const [moneyLoading, setMoneyLoading] = useState(true);
@@ -207,174 +213,214 @@ const Shop: React.FC<Props> = ({ userId, isVKEnvironment = false }) => {
     [money]
   );
 
-  return (
-    <div className="p-6">
-      {/* Общий спиннер на время загрузки кошелька */}
-      {moneyLoading && (
-        <div className="w-full flex items-center justify-center py-16">
-          <div className="w-12 h-12 border-4 border-purple-500 border-t-transparent rounded-full animate-spin" />
-        </div>
-      )}
+  const isDesktopView = isVKDesktop;
+  const renderContent = () => {
+    const loadingWrapperClass = isDesktopView
+      ? "w-full flex items-center justify-center py-16"
+      : "w-full flex items-center justify-center py-16";
+    const contentWrapperClass = isDesktopView
+      ? "mx-auto max-w-4xl space-y-8"
+      : "max-w-xl mx-auto";
+    const walletCardClass = isDesktopView
+      ? "flex items-center gap-6 rounded-3xl border-2 border-yellow-300 bg-gradient-to-r from-amber-50 via-yellow-50 to-amber-100 p-6 shadow-xl"
+      : "flex items-center gap-4 bg-yellow-50 border border-yellow-300 rounded-2xl p-4 shadow";
+    const walletLabelClass = isDesktopView
+      ? "text-sm uppercase tracking-[0.3em] text-yellow-700"
+      : "text-sm text-yellow-800/80";
+    const walletValueClass = isDesktopView
+      ? "text-3xl sm:text-4xl font-black text-yellow-800 leading-tight break-all"
+      : "text-xl sm:text-2xl md:text-3xl font-extrabold text-yellow-800 leading-tight break-all";
+    const walletButtonClass = isDesktopView
+      ? "px-6 py-3 rounded-2xl bg-purple-500 text-white font-semibold shadow-lg hover:bg-purple-600 transition"
+      : "px-4 py-2 rounded-xl bg-purple-500 text-white font-semibold shadow hover:bg-purple-600 transition";
+    const sectionTitleClass = isDesktopView
+      ? "text-2xl font-bold text-purple-800 mb-4"
+      : "text-lg font-semibold mb-3";
+    const shopSpinnerClass = isDesktopView
+      ? "w-full flex items-center justify-center py-12"
+      : "w-full flex items-center justify-center py-10";
+    const shopErrorClass = isDesktopView
+      ? "bg-red-50 text-red-700 border border-red-200 px-5 py-3 rounded-2xl shadow"
+      : "bg-red-50 text-red-700 border border-red-200 px-4 py-2 rounded";
+    const emptyStateClass = isDesktopView
+      ? "text-gray-500 text-lg text-center py-6"
+      : "text-gray-500";
+    const itemsListClass = isDesktopView
+      ? "grid grid-cols-2 gap-5"
+      : "grid grid-cols-1 gap-4";
+    const itemCardBase = isDesktopView
+      ? "rounded-3xl p-5 shadow-xl"
+      : "rounded-2xl p-4 shadow";
+    const itemImageClass = isDesktopView
+      ? "w-24 h-24 object-contain shrink-0 rounded-2xl bg-white/60"
+      : "w-20 h-20 object-contain shrink-0 rounded-xl bg-white/60";
+    const itemTitleClass = isDesktopView
+      ? "text-lg font-bold truncate"
+      : "text-base font-bold truncate";
+    const itemPriceClass = isDesktopView
+      ? "text-base font-semibold whitespace-nowrap"
+      : "text-sm font-semibold whitespace-nowrap";
+    const itemDescriptionClass = isDesktopView
+      ? "mt-2 text-sm text-gray-700 leading-relaxed line-clamp-4"
+      : "mt-1 text-sm text-gray-700 line-clamp-3";
+    const modalContainerClass = isDesktopView
+      ? "bg-white rounded-2xl shadow-2xl p-8 max-w-lg w-full mx-4"
+      : "bg-white rounded-xl shadow-xl p-6 max-w-md w-full mx-4";
+    const walletErrorClass = isDesktopView
+      ? "bg-red-100 text-red-700 border border-red-300 px-5 py-3 rounded-2xl mb-4"
+      : "bg-red-100 text-red-700 border border-red-300 px-4 py-2 rounded mb-4";
 
-      {!moneyLoading && (
-        <div className="max-w-xl mx-auto">
-          {/* Ошибка кошелька */}
-          {moneyError && (
-            <div className="bg-red-100 text-red-700 border border-red-300 px-4 py-2 rounded mb-4">
-              {moneyError}
-            </div>
-          )}
-
-          {/* Фрейм «Золотые монеты» */}
-          <div className="flex items-center gap-4 bg-yellow-50 border border-yellow-300 rounded-2xl p-4 shadow">
-            <img
-              src="https://storage.yandexcloud.net/svm/img/money.png"
-              alt="Золотые монеты"
-              className="w-16 h-16 object-contain"
-            />
-            <div className="flex-1 min-w-0">
-              <div className="text-sm text-yellow-800/80">Золотые монеты</div>
-              <div className="text-xl sm:text-2xl md:text-3xl font-extrabold text-yellow-800 leading-tight break-all">
-                {moneyFormatted}
-              </div>
-            </div>
-            <button
-              className="px-4 py-2 rounded-xl bg-purple-500 text-white font-semibold shadow hover:bg-purple-600 transition"
-              onClick={handleOpenCoinPacks}
-            >
-              Пополнить
-            </button>
+    return (
+      <>
+        {moneyLoading && (
+          <div className={loadingWrapperClass}>
+            <div className="w-12 h-12 border-4 border-purple-500 border-t-transparent rounded-full animate-spin" />
           </div>
+        )}
 
-          {/* Фрейм «Магазин» */}
-          <section aria-label="Магазин" className="mt-6">
-            <h2 className="text-lg font-semibold mb-3">Магазин</h2>
+        {!moneyLoading && (
+          <div className={contentWrapperClass}>
+            {moneyError && <div className={walletErrorClass}>{moneyError}</div>}
 
-            {/* Состояния загрузки/ошибки */}
-            {shopLoading && (
-              <div className="w-full flex items-center justify-center py-10">
-                <div className="w-10 h-10 border-4 border-sky-500 border-t-transparent rounded-full animate-spin" />
+            <div className={walletCardClass}>
+              <img
+                src="https://storage.yandexcloud.net/svm/img/money.png"
+                alt="Золотые монеты"
+                className="w-16 h-16 object-contain"
+              />
+              <div className="flex-1 min-w-0">
+                <div className={walletLabelClass}>Золотые монеты</div>
+                <div className={walletValueClass}>{moneyFormatted}</div>
               </div>
-            )}
-            {!shopLoading && shopError && (
-              <div className="bg-red-50 text-red-700 border border-red-200 px-4 py-2 rounded">
-                {shopError}
-              </div>
-            )}
-
-            {!shopLoading && !shopError && (
-              <div>
-                {items.length === 0 ? (
-                  <div className="text-gray-500">
-                    Товары временно отсутствуют.
-                  </div>
-                ) : (
-                  <ul className="grid grid-cols-1 gap-4">
-                    {items.map((it) => {
-                      const isActive = it.active !== false;
-                      const affordable = it.inventoryprice <= money;
-                      const isLoading = actionLoading === it.inventoryid;
-                      const clickable = isActive && affordable;
-                      return (
-                        <li
-                          key={it.inventoryid}
-                          className={`${badgeBg(
-                            it.inventorytype
-                          )} rounded-2xl p-4 shadow ${
-                            clickable
-                              ? "cursor-pointer hover:shadow-lg"
-                              : "opacity-50 cursor-not-allowed"
-                          } ${isActive ? "" : "grayscale"} relative`}
-                          onClick={() =>
-                            clickable ? handleBuy(it) : undefined
-                          }
-                          aria-disabled={!clickable}
-                        >
-                          <div className="flex items-start gap-4">
-                            <img
-                              src={it.inventoryimage}
-                              alt={it.inventoryname}
-                              className="w-20 h-20 object-contain shrink-0 rounded-xl bg-white/60"
-                              loading="lazy"
-                            />
-                            <div className="flex-1 min-w-0">
-                              <div className="flex items-center justify-between gap-3">
-                                <h3
-                                  className="text-base font-bold truncate"
-                                  title={it.inventoryname}
-                                >
-                                  {it.inventoryname}
-                                </h3>
-                                <div className="text-sm font-semibold whitespace-nowrap">
-                                  {new Intl.NumberFormat("ru-RU").format(
-                                    it.inventoryprice
-                                  )}
-                                </div>
-                              </div>
-                              <p className="mt-1 text-sm text-gray-700 line-clamp-3">
-                                {it.inventorydescription}
-                              </p>
-                            </div>
-                          </div>
-
-                          {/* Локальный спиннер покупки поверх карточки */}
-                          {isLoading && (
-                            <div className="absolute inset-0 flex items-center justify-center rounded-2xl bg-white/50">
-                              <div className="w-8 h-8 border-4 border-sky-500 border-t-transparent rounded-full animate-spin" />
-                            </div>
-                          )}
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </div>
-            )}
-          </section>
-        </div>
-      )}
-
-      {/* Модальное окно сообщения (всплывающее) */}
-      {showModal && (
-        <div
-          className="fixed inset-0 flex items-center justify-center z-50 bg-black/50"
-          onClick={() => {
-            setShowModal(false);
-            // После закрытия модалки — обновляем кошелёк
-            loadWallet();
-          }}
-        >
-          <div
-            className="bg-white rounded-xl shadow-xl p-6 max-w-md w-full mx-4"
-            onClick={(e) => e.stopPropagation()} // не закрывать при клике внутри окна
-          >
-            <div className="text-lg font-semibold mb-4">Сообщение</div>
-            <div className="text-gray-800 whitespace-pre-wrap">
-              {actionMessage}
-            </div>
-            <div className="mt-6 flex justify-end gap-3">
-              <button
-                onClick={() => {
-                  setShowModal(false);
-                  loadWallet(); // обновляем баланс и при закрытии по кнопке
-                }}
-                className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600"
-              >
-                OK
+              <button className={walletButtonClass} onClick={handleOpenCoinPacks}>
+                Пополнить
               </button>
             </div>
+
+            <section aria-label="Магазин" className={isDesktopView ? "mt-8" : "mt-6"}>
+              <h2 className={sectionTitleClass}>Магазин</h2>
+
+              {shopLoading && (
+                <div className={shopSpinnerClass}>
+                  <div className="w-10 h-10 border-4 border-sky-500 border-t-transparent rounded-full animate-spin" />
+                </div>
+              )}
+
+              {!shopLoading && shopError && (
+                <div className={shopErrorClass}>{shopError}</div>
+              )}
+
+              {!shopLoading && !shopError && (
+                <div>
+                  {items.length === 0 ? (
+                    <div className={emptyStateClass}>Товары временно отсутствуют.</div>
+                  ) : (
+                    <ul className={itemsListClass}>
+                      {items.map((it) => {
+                        const isActive = it.active !== false;
+                        const affordable = it.inventoryprice <= money;
+                        const isLoading = actionLoading === it.inventoryid;
+                        const clickable = isActive && affordable;
+                        const cardClasses = `${badgeBg(it.inventorytype)} ${itemCardBase} ${
+                          clickable
+                            ? "cursor-pointer hover:shadow-2xl hover:-translate-y-1 transition"
+                            : "opacity-50 cursor-not-allowed"
+                        } ${isActive ? "" : "grayscale"} relative`;
+
+                        return (
+                          <li
+                            key={it.inventoryid}
+                            className={cardClasses}
+                            onClick={() => (clickable ? handleBuy(it) : undefined)}
+                            aria-disabled={!clickable}
+                          >
+                            <div className="flex items-start gap-4">
+                              <img
+                                src={it.inventoryimage}
+                                alt={it.inventoryname}
+                                className={itemImageClass}
+                                loading="lazy"
+                              />
+                              <div className="flex-1 min-w-0">
+                                <div className="flex items-center justify-between gap-3">
+                                  <h3 className={itemTitleClass} title={it.inventoryname}>
+                                    {it.inventoryname}
+                                  </h3>
+                                  <div className={itemPriceClass}>
+                                    {new Intl.NumberFormat("ru-RU").format(
+                                      it.inventoryprice
+                                    )}
+                                  </div>
+                                </div>
+                                <p className={itemDescriptionClass}>{it.inventorydescription}</p>
+                              </div>
+                            </div>
+
+                            {isLoading && (
+                              <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-white/60">
+                                <div className="w-8 h-8 border-4 border-sky-500 border-t-transparent rounded-full animate-spin" />
+                              </div>
+                            )}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </section>
           </div>
-        </div>
-      )}
-      {showCoinPackSelector && (
-        <CoinPackSelector
-          onClose={handleCloseCoinPacks}
-          userId={userId}
-          isVK={isVKEnvironment}
-        />
-      )}
-    </div>
-  );
+        )}
+
+        {showModal && (
+          <div
+            className="fixed inset-0 flex items-center justify-center z-50 bg-black/50"
+            onClick={() => {
+              setShowModal(false);
+              loadWallet();
+            }}
+          >
+            <div
+              className={modalContainerClass}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="text-lg font-semibold mb-4">Сообщение</div>
+              <div className="text-gray-800 whitespace-pre-wrap">{actionMessage}</div>
+              <div className="mt-6 flex justify-end gap-3">
+                <button
+                  onClick={() => {
+                    setShowModal(false);
+                    loadWallet();
+                  }}
+                  className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600"
+                >
+                  OK
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {showCoinPackSelector && (
+          <CoinPackSelector
+            onClose={handleCloseCoinPacks}
+            userId={userId}
+            isVK={isVKEnvironment}
+          />
+        )}
+      </>
+    );
+  };
+
+  if (isDesktopView) {
+    return (
+      <VKDesktopFrame title="Магазин" accent="amber">
+        {renderContent()}
+      </VKDesktopFrame>
+    );
+  }
+
+  return <div className="p-6">{renderContent()}</div>;
 };
 
 export default Shop;

--- a/src/components/CompetitionEnergy.tsx
+++ b/src/components/CompetitionEnergy.tsx
@@ -8,9 +8,14 @@ import CompetitionEnergyReplenishment from "./CompetitionEnergyReplenishment";
 interface Props {
   userId: number;
   isVK?: boolean;
+  isVKDesktop?: boolean;
 }
 
-const CompetitionEnergy: React.FC<Props> = ({ userId, isVK = false }) => {
+const CompetitionEnergy: React.FC<Props> = ({
+  userId,
+  isVK = false,
+  isVKDesktop = false,
+}) => {
   const [energy, setEnergy] = useState<number | null>(null);
   const [next, setNext] = useState<string>("");
   const [timer, setTimer] = useState<number>(0);
@@ -56,10 +61,19 @@ const CompetitionEnergy: React.FC<Props> = ({ userId, isVK = false }) => {
 
   if (energy == null) return null;
 
+  const wrapperClass = isVKDesktop
+    ? "w-full mb-6"
+    : "w-full flex justify-center mb-6 md:mb-0";
+  const cardClassBase =
+    "flex flex-col items-center md:justify-between rounded-xl border-2 border-blue-300 bg-blue-50 shadow-md p-4";
+  const cardClass = `${cardClassBase} ${
+    isVKDesktop ? "w-full" : "w-full md:w-auto md:h-[282px]"
+  }`;
+
   return (
     <>
-      <div className="w-full flex justify-center mb-6 md:mb-0">
-        <div className="flex flex-col items-center md:justify-between rounded-xl border-2 border-blue-300 bg-blue-50 shadow-md p-4 w-full md:w-auto md:h-[282px]">
+      <div className={wrapperClass}>
+        <div className={cardClass}>
           <div className="flex items-center gap-3">
             <img
               src={IMAGES.competitionEnergy}

--- a/src/components/CurrentCompetition.tsx
+++ b/src/components/CurrentCompetition.tsx
@@ -1,6 +1,7 @@
 // src/components/CurrentCompetition.tsx
 import React, { useState, useEffect } from "react";
 import axios from "axios";
+import VKDesktopFrame from "./VKDesktopFrame";
 
 // Типы данных
 interface PrizeItem {
@@ -69,9 +70,13 @@ interface CompetitionData {
 
 interface Props {
   competitionsInstanceId: number;
+  isVKDesktop?: boolean;
 }
 
-const CurrentCompetition: React.FC<Props> = ({ competitionsInstanceId }) => {
+const CurrentCompetition: React.FC<Props> = ({
+  competitionsInstanceId,
+  isVKDesktop = false,
+}) => {
   const [data, setData] = useState<CompetitionData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -79,7 +84,6 @@ const CurrentCompetition: React.FC<Props> = ({ competitionsInstanceId }) => {
   const [viewedSteps, setViewedSteps] = useState<Set<number>>(new Set([0]));
   const [showPrizeModal, setShowPrizeModal] = useState(false);
 
-  // Загрузка данных состязания
   useEffect(() => {
     const loadData = async () => {
       try {
@@ -95,10 +99,10 @@ const CurrentCompetition: React.FC<Props> = ({ competitionsInstanceId }) => {
         setLoading(false);
       }
     };
+
     loadData();
   }, [competitionsInstanceId]);
 
-  // Подсчет очков для монстров
   const calculateScores = (): Record<number, number> => {
     if (!data) return {};
 
@@ -118,7 +122,6 @@ const CurrentCompetition: React.FC<Props> = ({ competitionsInstanceId }) => {
     return scores;
   };
 
-  // Обработчик перехода к следующему шагу
   const handleNextStep = () => {
     if (!data) return;
     const nextIndex = currentStepIndex + 1;
@@ -126,19 +129,31 @@ const CurrentCompetition: React.FC<Props> = ({ competitionsInstanceId }) => {
     setViewedSteps((prev) => new Set([...prev, nextIndex]));
   };
 
-  // Обработчик выбора вкладки
   const handleTabClick = (index: number) => {
     if (viewedSteps.has(index)) {
       setCurrentStepIndex(index);
     }
   };
 
-  // Закрытие состязания и возврат в Арену
   const handleClose = () => {
-    window.location.reload(); // Перезагружаем для возврата в Арену
+    window.location.reload();
   };
 
   if (loading) {
+    const spinner = (
+      <div className="flex items-center justify-center h-full py-20">
+        <div className="w-12 h-12 border-4 border-purple-500 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+
+    if (isVKDesktop) {
+      return (
+        <VKDesktopFrame title="Соревнование" accent="blue">
+          {spinner}
+        </VKDesktopFrame>
+      );
+    }
+
     return (
       <div className="flex items-center justify-center h-screen">
         <div className="w-12 h-12 border-4 border-purple-500 border-t-transparent rounded-full animate-spin" />
@@ -147,9 +162,9 @@ const CurrentCompetition: React.FC<Props> = ({ competitionsInstanceId }) => {
   }
 
   if (error || !data) {
-    return (
-      <div className="p-8 text-center">
-        <div className="text-red-500 text-xl mb-4">{error || "Ошибка загрузки"}</div>
+    const errorContent = (
+      <div className="text-center space-y-4">
+        <div className="text-red-500 text-xl">{error || "Ошибка загрузки"}</div>
         <button
           onClick={handleClose}
           className="px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600"
@@ -158,346 +173,389 @@ const CurrentCompetition: React.FC<Props> = ({ competitionsInstanceId }) => {
         </button>
       </div>
     );
+
+    if (isVKDesktop) {
+      return (
+        <VKDesktopFrame title="Соревнование" accent="blue">
+          {errorContent}
+        </VKDesktopFrame>
+      );
+    }
+
+    return <div className="p-8 text-center">{errorContent}</div>;
   }
 
   const steps = data.competitionsinstance.competitionsinstancessteps;
   const currentStep = steps[currentStepIndex];
   const scores = calculateScores();
   const isLastStep = currentStepIndex === steps.length - 1;
+  const isDesktopView = isVKDesktop;
 
-  return (
-    <div className="min-h-screen bg-gradient-to-b from-purple-200 to-orange-200 p-4">
-      <div className="max-w-7xl mx-auto">
-        {/* Компонент "Соперники" */}
-        <div className="mb-6">
-          <div className="bg-gradient-to-br from-purple-50 to-pink-50 rounded-2xl border-2 border-purple-200 shadow-lg p-4">
-            <div className="flex flex-wrap gap-4 justify-center">
-              {data.competitionsinstance.monstercharacteristics.map((monster) => {
-                const items = data.competitionsinstance.monsteritems.find(
-                  (mi) => mi.monsteridforitem === monster.monsteridforchar
-                );
+  const containerClass = isDesktopView ? "space-y-8" : "max-w-7xl mx-auto";
+  const opponentsSectionClass = isDesktopView ? "mb-8" : "mb-6";
+  const opponentsCardClass = isDesktopView
+    ? "bg-white/95 rounded-3xl border-2 border-blue-200 shadow-xl p-6"
+    : "bg-gradient-to-br from-purple-50 to-pink-50 rounded-2xl border-2 border-purple-200 shadow-lg p-4";
+  const scoreboardCardClass = isDesktopView
+    ? "bg-white/95 rounded-3xl border-2 border-emerald-200 shadow-xl p-6"
+    : "bg-gradient-to-br from-green-50 to-emerald-50 rounded-2xl border-2 border-green-200 shadow-lg p-4";
+  const stepsWrapperClass = isDesktopView
+    ? "bg-white/95 rounded-3xl shadow-xl overflow-hidden border border-purple-200"
+    : "bg-white rounded-2xl shadow-lg overflow-hidden";
+  const tabsColumnClass = isDesktopView
+    ? "w-24 bg-gradient-to-b from-slate-100 to-slate-200 border-r border-purple-100"
+    : "w-20 bg-gray-100 border-r border-gray-200";
+  const contentPaddingClass = isDesktopView ? "flex-1 p-8" : "flex-1 p-6";
+  const actionButtonClass = isDesktopView
+    ? "px-7 py-3 rounded-xl font-semibold shadow-lg transition-colors"
+    : "px-6 py-3 rounded-lg font-semibold shadow-lg transition-colors";
+  const prizeModalContainerClass = isDesktopView
+    ? "fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-6"
+    : "fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4";
+  const prizeModalContentClass = isDesktopView
+    ? "bg-white rounded-3xl shadow-2xl p-8 max-w-3xl w-full"
+    : "bg-white rounded-2xl shadow-2xl p-6 max-w-2xl w-full";
 
-                return (
-                  <div
-                    key={monster.monsteridforchar}
-                    className="relative bg-gradient-to-br from-violet-100 via-purple-50 to-pink-100 rounded-xl p-4 shadow-lg border-2 border-purple-200 hover:shadow-xl transition-all duration-300 min-w-[280px] max-w-[350px] overflow-hidden"
-                  >
-                    {/* Декоративный элемент в углу */}
-                    <div className="absolute -top-10 -right-10 w-32 h-32 bg-gradient-to-br from-purple-300/20 to-pink-300/20 rounded-full blur-2xl" />
-                    
-                    {/* Имя монстра */}
-                    <h3 className="relative text-lg font-bold bg-gradient-to-r from-purple-700 to-pink-600 bg-clip-text text-transparent text-center mb-4">
-                      {monster.monstername}
-                    </h3>
+  const renderContent = () => (
+    <div className={containerClass}>
+      <div className={opponentsSectionClass}>
+        <div className={opponentsCardClass}>
+          <div className="flex flex-wrap gap-4 justify-center">
+            {data.competitionsinstance.monstercharacteristics.map((monster) => {
+              const items = data.competitionsinstance.monsteritems.find(
+                (mi) => mi.monsteridforitem === monster.monsteridforchar
+              );
 
-                    {/* Характеристики - сетка по центру */}
-                    <div className="relative flex justify-center mb-4">
-                      <div className="grid grid-cols-3 gap-2">
-                        {monster.characteristics.slice(0, 6).map((char) => (
+              return (
+                <div
+                  key={monster.monsteridforchar}
+                  className={`relative bg-gradient-to-br from-violet-100 via-purple-50 to-pink-100 ${
+                    isDesktopView
+                      ? "rounded-3xl p-6 shadow-xl border-2 border-purple-200"
+                      : "rounded-xl p-4 shadow-lg border-2 border-purple-200"
+                  } hover:shadow-2xl transition-all duration-300 min-w-[280px] max-w-[360px] overflow-hidden`}
+                >
+                  <div className="absolute -top-10 -right-10 w-32 h-32 bg-gradient-to-br from-purple-300/20 to-pink-300/20 rounded-full blur-2xl" />
+
+                  <h3 className="relative text-lg font-bold bg-gradient-to-r from-purple-700 to-pink-600 bg-clip-text text-transparent text-center mb-4">
+                    {monster.monstername}
+                  </h3>
+
+                  <div className="relative flex justify-center mb-4">
+                    <div className="grid grid-cols-3 gap-2">
+                      {monster.characteristics.slice(0, 6).map((char) => (
+                        <div
+                          key={char.characteristicid}
+                          className="flex flex-col items-center bg-white/70 backdrop-blur-sm rounded-lg px-3 py-2 border border-purple-200 hover:bg-white/90 transition-all duration-200 group"
+                          title={char.name}
+                        >
+                          <img
+                            src={char.icon}
+                            alt={char.name}
+                            className="w-6 h-6 mb-1 group-hover:scale-110 transition-transform"
+                          />
+                          <span className="text-sm font-bold text-purple-700">
+                            {char.value}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  {items && items.items.length > 0 && (
+                    <div className="relative pt-3 border-t-2 border-purple-200/50">
+                      <div className="flex flex-wrap gap-2 justify-center">
+                        {items.items.map((item) => (
                           <div
-                            key={char.characteristicid}
-                            className="flex flex-col items-center bg-white/70 backdrop-blur-sm rounded-lg px-3 py-2 border border-purple-200 hover:bg-white/90 transition-all duration-200 group"
-                            title={char.name}
+                            key={item.inventoryid}
+                            className={`relative group ${
+                              item.activity === "false" ? "opacity-50" : ""
+                            }`}
+                            title={`${item.inventoryname}: ${item.inventorydescription}`}
                           >
-                            <img 
-                              src={char.icon} 
-                              alt={char.name} 
-                              className="w-6 h-6 mb-1 group-hover:scale-110 transition-transform" 
-                            />
-                            <span className="text-sm font-bold text-purple-700">
-                              {char.value}
-                            </span>
+                            <div className="bg-white/60 backdrop-blur-sm rounded-lg p-1.5 border border-purple-200 hover:bg-white/80 transition-all duration-200">
+                              <img
+                                src={item.inventoryimage}
+                                alt={item.inventoryname}
+                                className="w-8 h-8 object-contain group-hover:scale-110 transition-transform"
+                              />
+                            </div>
+                            {item.activity === "true" && (
+                              <div className="absolute -top-1 -right-1 w-2 h-2 bg-green-400 rounded-full animate-pulse" />
+                            )}
                           </div>
                         ))}
                       </div>
                     </div>
-
-                    {/* Предметы */}
-                    {items && items.items.length > 0 && (
-                      <div className="relative pt-3 border-t-2 border-purple-200/50">
-                        <div className="flex flex-wrap gap-2 justify-center">
-                          {items.items.map((item) => (
-                            <div
-                              key={item.inventoryid}
-                              className={`relative group ${
-                                item.activity === "false" ? "opacity-50" : ""
-                              }`}
-                              title={`${item.inventoryname}: ${item.inventorydescription}`}
-                            >
-                              <div className="bg-white/60 backdrop-blur-sm rounded-lg p-1.5 border border-purple-200 hover:bg-white/80 transition-all duration-200">
-                                <img
-                                  src={item.inventoryimage}
-                                  alt={item.inventoryname}
-                                  className="w-8 h-8 object-contain group-hover:scale-110 transition-transform"
-                                />
-                              </div>
-                              {item.activity === "true" && (
-                                <div className="absolute -top-1 -right-1 w-2 h-2 bg-green-400 rounded-full animate-pulse" />
-                              )}
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
+      </div>
 
-        {/* Компонент "Общий счет" */}
-        <div className="mb-6">
-          <div className="bg-gradient-to-br from-green-50 to-emerald-50 rounded-2xl border-2 border-green-200 shadow-lg p-4">
-            <div className="flex justify-center gap-8">
-              {data.competitionsinstance.monstercharacteristics.map((monster) => (
-                <div
-                  key={monster.monsteridforchar}
-                  className="bg-white rounded-xl px-8 py-4 shadow-md border-2 border-green-300"
-                >
-                  <div className="text-center">
-                    <div className="text-sm text-gray-600 mb-1">
-                      {monster.monstername}
-                    </div>
-                    <div className="text-4xl font-bold text-green-600">
-                      {scores[monster.monsteridforchar] || 0}
+      <div className={isDesktopView ? "mb-8" : "mb-6"}>
+        <div className={scoreboardCardClass}>
+          <div className="flex justify-center gap-8">
+            {data.competitionsinstance.monstercharacteristics.map((monster) => (
+              <div
+                key={monster.monsteridforchar}
+                className={
+                  isDesktopView
+                    ? "bg-white rounded-2xl px-8 py-5 shadow-lg border-2 border-green-300"
+                    : "bg-white rounded-xl px-8 py-4 shadow-md border-2 border-green-300"
+                }
+              >
+                <div className="text-center">
+                  <div className="text-sm text-gray-600 mb-1">
+                    {monster.monstername}
+                  </div>
+                  <div className="text-4xl font-bold text-green-600">
+                    {scores[monster.monsteridforchar] || 0}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className={stepsWrapperClass}>
+        <div className="flex">
+          <div className={tabsColumnClass}>
+            {steps.map((step, index) => (
+              <button
+                key={step.sequence}
+                className={`w-full px-3 py-4 text-sm font-medium transition-colors ${
+                  currentStepIndex === index
+                    ? "bg-purple-500 text-white"
+                    : viewedSteps.has(index)
+                    ? "bg-white text-gray-700 hover:bg-gray-50"
+                    : "bg-gray-200 text-gray-400 cursor-not-allowed"
+                }`}
+                onClick={() => handleTabClick(index)}
+                disabled={!viewedSteps.has(index)}
+              >
+                {step.sequence}
+              </button>
+            ))}
+          </div>
+
+          <div className={contentPaddingClass}>
+            {currentStep && (
+              <>
+                <h3 className="text-2xl font-bold text-gray-800 mb-2">
+                  {currentStep.name}
+                </h3>
+                <p className="text-gray-600 mb-4">{currentStep.description}</p>
+
+                <div className="mb-6 flex justify-center">
+                  <div className="relative max-w-2xl w-full">
+                    <div
+                      className="relative w-full rounded-lg shadow-md overflow-visible"
+                      style={{ backgroundColor: "#f3f4f6" }}
+                    >
+                      <img
+                        src={currentStep.image}
+                        alt={currentStep.name}
+                        className="w-full h-auto block"
+                        style={{ maxWidth: "100%" }}
+                      />
+
+                      {currentStep.monsters.map((monster) => {
+                        const monsterInfo =
+                          data.competitionsinstance.monstercharacteristics.find(
+                            (m) => m.monsteridforchar === monster.monsterid
+                          );
+                        if (!monsterInfo) return null;
+
+                        const spriteSize = monster.scale;
+
+                        return (
+                          <img
+                            key={monster.monsterid}
+                            src={monsterInfo.monsterimage}
+                            alt={monsterInfo?.monstername ?? ""}
+                            className="absolute"
+                            style={{
+                              left: `${monster.xaxis}%`,
+                              top: `${monster.yaxis}%`,
+                              width: `${spriteSize}%`,
+                              height: "auto",
+                              transform: "translate(-50%, -50%)",
+                              zIndex: 10,
+                              maxWidth: "150px",
+                            }}
+                          />
+                        );
+                      })}
                     </div>
                   </div>
                 </div>
-              ))}
-            </div>
-          </div>
-        </div>
 
-        {/* Компонент "Шаги состязания" */}
-        <div className="bg-white rounded-2xl shadow-lg overflow-hidden">
-          <div className="flex">
-            {/* Вкладки слева */}
-            <div className="w-20 bg-gray-100 border-r border-gray-200">
-              {steps.map((step, index) => (
-                <button
-                  key={step.sequence}
-                  className={`w-full px-3 py-4 text-sm font-medium transition-colors ${
-                    currentStepIndex === index
-                      ? "bg-purple-500 text-white"
-                      : viewedSteps.has(index)
-                      ? "bg-white text-gray-700 hover:bg-gray-50"
-                      : "bg-gray-200 text-gray-400 cursor-not-allowed"
-                  }`}
-                  onClick={() => handleTabClick(index)}
-                  disabled={!viewedSteps.has(index)}
-                >
-                  {step.sequence}
-                </button>
-              ))}
-            </div>
-
-            {/* Содержимое шага */}
-            <div className="flex-1 p-6">
-              {currentStep && (
-                <>
-                  <h3 className="text-2xl font-bold text-gray-800 mb-2">
-                    {currentStep.name}
-                  </h3>
-                  <p className="text-gray-600 mb-4">{currentStep.description}</p>
-
-                  {/* Изображение шага с позиционированными монстрами */}
-                  <div className="mb-6 flex justify-center">
-                    <div className="relative max-w-2xl w-full">
-                      <div 
-                        className="relative w-full rounded-lg shadow-md overflow-visible"
-                        style={{ 
-                          // Не фиксируем соотношение сторон, позволяем изображению определять высоту
-                          backgroundColor: '#f3f4f6'
-                        }}
-                      >
-                        {/* Фоновое изображение - используем как базу для размеров */}
-                        <img
-                          src={currentStep.image}
-                          alt={currentStep.name}
-                          className="w-full h-auto block"
-                          style={{ maxWidth: '100%' }}
-                        />
-                        
-                        {/* Спрайты монстров - позиционируем относительно реального размера изображения */}
-                        {currentStep.monsters.map((monster) => {
-                          const monsterInfo = data.competitionsinstance.monstercharacteristics.find(
-                            (m) => m.monsteridforchar === monster.monsterid
-                          );
-                          if (!monsterInfo) return null;
-
-                          // Размер спрайта будет зависеть от параметра scale
-                          // scale=100 означает полный размер, scale=27 означает 27% от полного размера
-                          // Используем фиксированный базовый размер относительно контейнера
-                          const spriteSize = monster.scale; // Используем scale напрямую как процент от контейнера
-                          
-                          return (
-                            <img
-                              key={monster.monsterid}
-                              src={monsterInfo.monsterimage}
-                              alt={monsterInfo.monstername}
-                              className="absolute"
-                              style={{
-                                left: `${monster.xaxis}%`,
-                                top: `${monster.yaxis}%`,
-                                width: `${spriteSize}%`,
-                                height: 'auto',
-                                transform: 'translate(-50%, -50%)',
-                                zIndex: 10,
-                                maxWidth: '150px', // Ограничиваем максимальный размер спрайта
-                              }}
-                            />
-                          );
-                        })}
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Результаты для каждого соперника */}
-                  <div className="space-y-4">
-                    {currentStep.monsters.map((monster) => {
-                      const monsterInfo = data.competitionsinstance.monstercharacteristics.find(
+                <div className="space-y-4">
+                  {currentStep.monsters.map((monster) => {
+                    const monsterInfo =
+                      data.competitionsinstance.monstercharacteristics.find(
                         (m) => m.monsteridforchar === monster.monsterid
                       );
 
-                      return (
-                        <div
-                          key={monster.monsterid}
-                          className={`p-4 rounded-lg border-2 transition-all duration-300 ${
-                            monster.winner
-                              ? "border-green-400 bg-gradient-to-r from-green-50 to-emerald-50 shadow-md"
-                              : "border-gray-300 bg-gradient-to-r from-gray-50 to-slate-50"
-                          }`}
-                        >
-                          <div className="flex items-center justify-between">
-                            <div className="flex-1">
-                              <div className={`font-bold text-lg ${
-                                monster.winner ? "text-green-800" : "text-gray-800"
-                              }`}>
-                                {monsterInfo?.monstername}
-                              </div>
-                              <div className={`text-sm mt-1 ${
-                                monster.winner ? "text-green-700" : "text-gray-600"
-                              }`}>
-                                {monster.formulatext}
-                              </div>
-                            </div>
-                            <div className="text-right ml-4">
-                              <div
-                                className={`text-3xl font-bold ${
-                                  monster.winner 
-                                    ? "text-transparent bg-gradient-to-r from-green-600 to-emerald-600 bg-clip-text" 
-                                    : "text-gray-600"
-                                }`}
-                              >
-                                {monster.points}
-                              </div>
-                              {monster.winner && (
-                                <div className="flex items-center justify-end gap-1 mt-1">
-                                  <span className="text-green-600 text-sm font-medium">Победа</span>
-                                  <svg className="w-4 h-4 text-green-600" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-                                  </svg>
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-
-                  {/* Кнопка продолжить/награждение */}
-                  <div className="mt-6 flex justify-center">
-                    {isLastStep ? (
-                      <button
-                        onClick={() => setShowPrizeModal(true)}
-                        className="px-6 py-3 bg-gold-500 text-white rounded-lg font-semibold shadow-lg hover:bg-gold-600 transition-colors bg-gradient-to-r from-yellow-400 to-yellow-600"
-                      >
-                        Награждение победителей
-                      </button>
-                    ) : (
-                      <button
-                        onClick={handleNextStep}
-                        className="px-6 py-3 bg-purple-500 text-white rounded-lg font-semibold shadow-lg hover:bg-purple-600 transition-colors"
-                      >
-                        Продолжить
-                      </button>
-                    )}
-                  </div>
-                </>
-              )}
-            </div>
-          </div>
-        </div>
-
-        {/* Компонент "Награждение победителей" */}
-        {showPrizeModal && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-            <div className="bg-white rounded-2xl shadow-2xl p-6 max-w-2xl w-full">
-              <h2 className="text-2xl font-bold text-center mb-6 text-purple-800">
-                Награждение победителей
-              </h2>
-
-              <div className="flex flex-col items-center">
-                {/* Приз */}
-                <div className="mb-6">
-                  <div className="bg-gradient-to-br from-yellow-50 to-amber-50 rounded-xl p-6 border-2 border-yellow-300 shadow-lg">
-                    <img
-                      src={data.competitionsinstance.prizeitem.prizeitemimage}
-                      alt={data.competitionsinstance.prizeitem.prizeitemname}
-                      className="w-24 h-24 mx-auto mb-4 object-contain"
-                    />
-                    <h3 className="text-xl font-bold text-amber-800 text-center mb-2">
-                      {data.competitionsinstance.prizeitem.prizeitemname}
-                    </h3>
-                    <p className="text-amber-700 text-center">
-                      {data.competitionsinstance.prizeitem.prizeitemdescr}
-                    </p>
-                  </div>
-                </div>
-
-                {/* Стрелка вниз */}
-                <div className="text-4xl text-purple-500 mb-4">↓</div>
-
-                {/* Победители */}
-                <div className="flex flex-wrap gap-4 justify-center">
-                  {data.competitionsinstance.monsterswinners.map((winner) => {
-                    const monsterInfo = data.competitionsinstance.monstercharacteristics.find(
-                      (m) => m.monsteridforchar === winner.monsterwinnerid
-                    );
-
                     return (
                       <div
-                        key={winner.monsterwinnerid}
-                        className="bg-gradient-to-br from-purple-50 to-pink-50 rounded-xl p-4 border-2 border-purple-300 shadow-md"
+                        key={monster.monsterid}
+                        className={`p-4 rounded-lg border-2 transition-all duration-300 ${
+                          monster.winner
+                            ? "border-green-400 bg-gradient-to-r from-green-50 to-emerald-50 shadow-md"
+                            : "border-gray-300 bg-gradient-to-r from-gray-50 to-slate-50"
+                        }`}
                       >
-                        <img
-                          src={monsterInfo?.monsterimage}
-                          alt={monsterInfo?.monstername}
-                          className="w-20 h-20 mx-auto mb-2 object-contain"
-                        />
-                        <div className="text-center font-semibold text-purple-800">
-                          {monsterInfo?.monstername}
+                        <div className="flex items-center justify-between">
+                          <div className="flex-1">
+                            <div
+                              className={`font-bold text-lg ${
+                                monster.winner ? "text-green-800" : "text-gray-800"
+                              }`}
+                            >
+                              {monsterInfo?.monstername}
+                            </div>
+                            <div
+                              className={`text-sm mt-1 ${
+                                monster.winner ? "text-green-700" : "text-gray-600"
+                              }`}
+                            >
+                              {monster.formulatext}
+                            </div>
+                          </div>
+                          <div className="text-right ml-4">
+                            <div
+                              className={`text-3xl font-bold ${
+                                monster.winner
+                                  ? "text-transparent bg-gradient-to-r from-green-600 to-emerald-600 bg-clip-text"
+                                  : "text-gray-600"
+                              }`}
+                            >
+                              {monster.points}
+                            </div>
+                            {monster.winner && (
+                              <div className="flex items-center justify-end gap-1 mt-1">
+                                <span className="text-green-600 text-sm font-medium">Победа</span>
+                                <svg className="w-4 h-4 text-green-600" fill="currentColor" viewBox="0 0 20 20">
+                                  <path
+                                    fillRule="evenodd"
+                                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                                    clipRule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                            )}
+                          </div>
                         </div>
                       </div>
                     );
                   })}
                 </div>
+
+                <div className="mt-6 flex justify-center">
+                  {isLastStep ? (
+                    <button
+                      onClick={() => setShowPrizeModal(true)}
+                      className={`${actionButtonClass} bg-gradient-to-r from-yellow-400 to-yellow-600 text-white`}
+                    >
+                      Награждение победителей
+                    </button>
+                  ) : (
+                    <button
+                      onClick={handleNextStep}
+                      className={`${actionButtonClass} bg-purple-500 text-white hover:bg-purple-600`}
+                    >
+                      Продолжить
+                    </button>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {showPrizeModal && (
+        <div className={prizeModalContainerClass}>
+          <div className={prizeModalContentClass}>
+            <h2 className="text-2xl font-bold text-center mb-6 text-purple-800">
+              Награждение победителей
+            </h2>
+
+            <div className="flex flex-col items-center">
+              <div className="mb-6">
+                <div className="bg-gradient-to-br from-yellow-50 to-amber-50 rounded-xl p-6 border-2 border-yellow-300 shadow-lg">
+                  <img
+                    src={data.competitionsinstance.prizeitem.prizeitemimage}
+                    alt={data.competitionsinstance.prizeitem.prizeitemname}
+                    className="w-24 h-24 mx-auto mb-4 object-contain"
+                  />
+                  <h3 className="text-xl font-bold text-amber-800 text-center mb-2">
+                    {data.competitionsinstance.prizeitem.prizeitemname}
+                  </h3>
+                  <p className="text-amber-700 text-center">
+                    {data.competitionsinstance.prizeitem.prizeitemdescr}
+                  </p>
+                </div>
               </div>
 
-              <div className="mt-6 flex justify-center">
-                <button
-                  onClick={handleClose}
-                  className="px-6 py-3 bg-purple-500 text-white rounded-lg font-semibold shadow-lg hover:bg-purple-600 transition-colors"
-                >
-                  Закрыть
-                </button>
+              <div className="text-4xl text-purple-500 mb-4">↓</div>
+
+              <div className="flex flex-wrap gap-4 justify-center">
+                {data.competitionsinstance.monsterswinners.map((winner) => {
+                  const monsterInfo =
+                    data.competitionsinstance.monstercharacteristics.find(
+                      (m) => m.monsteridforchar === winner.monsterwinnerid
+                    );
+
+                  return (
+                    <div
+                      key={winner.monsterwinnerid}
+                      className="bg-gradient-to-br from-purple-50 to-pink-50 rounded-xl p-4 border-2 border-purple-300 shadow-md"
+                    >
+                      <img
+                        src={monsterInfo?.monsterimage}
+                        alt={monsterInfo?.monstername}
+                        className="w-20 h-20 mx-auto mb-2 object-contain"
+                      />
+                      <div className="text-center font-semibold text-purple-800">
+                        {monsterInfo?.monstername}
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             </div>
+
+            <div className="mt-6 flex justify-center">
+              <button
+                onClick={handleClose}
+                className={`${actionButtonClass} bg-purple-500 text-white hover:bg-purple-600`}
+              >
+                Закрыть
+              </button>
+            </div>
           </div>
-        )}
-      </div>
+        </div>
+      )}
+    </div>
+  );
+
+  if (isDesktopView) {
+    return (
+      <VKDesktopFrame title="Соревнование" accent="blue">
+        {renderContent()}
+      </VKDesktopFrame>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-purple-200 to-orange-200 p-4">
+      {renderContent()}
     </div>
   );
 };

--- a/src/components/VKDesktopFrame.tsx
+++ b/src/components/VKDesktopFrame.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+type Accent = "purple" | "amber" | "emerald" | "blue";
+
+const ACCENT_CLASS_MAP: Record<Accent, string> = {
+  purple: "from-purple-500 to-orange-500",
+  amber: "from-amber-500 to-orange-400",
+  emerald: "from-emerald-500 to-teal-500",
+  blue: "from-sky-500 to-blue-600",
+};
+
+interface Props {
+  title: string;
+  accent?: Accent;
+  children: React.ReactNode;
+  contentClassName?: string;
+}
+
+const VKDesktopFrame: React.FC<Props> = ({
+  title,
+  accent = "purple",
+  children,
+  contentClassName = "",
+}) => {
+  const accentGradient = ACCENT_CLASS_MAP[accent];
+
+  return (
+    <div className="vk-desktop-screen">
+      <div className="vk-desktop-screen__frame">
+        <div
+          className={`vk-desktop-screen__header bg-gradient-to-r ${accentGradient}`}
+        >
+          {title}
+        </div>
+        <div className={`vk-desktop-screen__content ${contentClassName}`}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VKDesktopFrame;

--- a/src/index.css
+++ b/src/index.css
@@ -5,3 +5,58 @@
 .font-handwritten {
   font-family: "Handwritten", cursive;
 }
+
+.vk-desktop-screen {
+  min-height: calc(100vh - 0px);
+  display: flex;
+  justify-content: center;
+  padding: 24px 0;
+  background: linear-gradient(180deg, #ede9fe 0%, #fef3c7 100%);
+}
+
+.vk-desktop-screen__frame {
+  width: 1000px;
+  height: 1850px;
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 32px;
+  border: 1px solid rgba(124, 58, 237, 0.15);
+  box-shadow: 0 24px 60px rgba(120, 53, 15, 0.25);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.vk-desktop-screen__header {
+  padding: 24px;
+  text-align: center;
+  font-size: 32px;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.vk-desktop-screen__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px 48px 48px;
+  background: linear-gradient(180deg, rgba(250, 245, 255, 0.9) 0%, rgba(255, 247, 237, 0.9) 100%);
+}
+
+.vk-desktop-screen__content::-webkit-scrollbar {
+  width: 10px;
+}
+
+.vk-desktop-screen__content::-webkit-scrollbar-track {
+  background: rgba(243, 232, 255, 0.6);
+  border-radius: 999px;
+}
+
+.vk-desktop-screen__content::-webkit-scrollbar-thumb {
+  background: rgba(139, 92, 246, 0.6);
+  border-radius: 999px;
+}
+
+.vk-desktop-screen__content::-webkit-scrollbar-thumb:hover {
+  background: rgba(124, 58, 237, 0.8);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -90,7 +90,9 @@ type MonsterTypesResponse = {
 
 const App: React.FC = () => {
   // ---- state ----
-  const isVKEnvironment = useMemo(() => getVKParams().VK, []);
+  const vkParams = useMemo(() => getVKParams(), []);
+  const isVKEnvironment = vkParams.VK;
+  const VKdesktop = vkParams.VKdesktop;
   const [userId, setUserId] = useState<number | null>(null);
   const [monstersId, setMonstersId] = useState<number[]>([]);
   const [menuItems, setMenuItems] = useState<MenuItem[]>([]);
@@ -1040,15 +1042,23 @@ const App: React.FC = () => {
       {/* Остальные разделы */}
       {!showRaisingInteraction &&
         selectedMenuSequence === MENU_SEQUENCES.ARENA && (
-          <Arena userId={userId} isVK={isVKEnvironment} />
+          <Arena
+            userId={userId}
+            isVK={isVKEnvironment}
+            isVKDesktop={VKdesktop}
+          />
         )}
       {!showRaisingInteraction &&
         selectedMenuSequence === MENU_SEQUENCES.SHOP && (
-          <Shop userId={userId} isVKEnvironment={isVKEnvironment} />
+          <Shop
+            userId={userId}
+            isVKEnvironment={isVKEnvironment}
+            isVKDesktop={VKdesktop}
+          />
         )}
       {!showRaisingInteraction &&
         selectedMenuSequence === MENU_SEQUENCES.INVENTORY && (
-          <Inventory userId={userId} />
+          <Inventory userId={userId} isVKDesktop={VKdesktop} />
         )}
       {!showRaisingInteraction &&
         selectedMenuSequence === MENU_SEQUENCES.ACCOUNT && (

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -94,12 +94,14 @@ export async function withInfiniteRetryAndTimeout<T>(
 
 export const getVKParams = (): {
   VK: boolean;
+  VKdesktop: boolean;
   sign: string | null;
   vkUserId: string | null;
 } => {
   if (typeof window === "undefined") {
     return {
       VK: false,
+      VKdesktop: false,
       sign: null,
       vkUserId: null,
     };
@@ -108,9 +110,13 @@ export const getVKParams = (): {
   const search = window.location?.search ?? "";
   const params = new URLSearchParams(search);
 
+  const platform = params.get("vk_platform");
+  const VKdesktop = platform === "desktop_web";
+
   if (!params.has("vk_user_id")) {
     return {
       VK: false,
+      VKdesktop,
       sign: null,
       vkUserId: null,
     };
@@ -120,6 +126,7 @@ export const getVKParams = (): {
 
   return {
     VK,
+    VKdesktop,
     sign: params.get("sign"),
     vkUserId: params.get("vk_user_id"),
   };


### PR DESCRIPTION
## Summary
- detect the VK desktop platform parameter and surface a VKdesktop flag through the app
- add a reusable VKDesktopFrame wrapper and tailored desktop layouts for Arena, Shop, Inventory, and competition screens
- update the competition energy widget to support the desktop presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de5f025be4832a8ce69049a71961ef