### PR TITLE
Remove shop heading for VK Desktop view

### DIFF
--- a/src/Shop.tsx
+++ b/src/Shop.tsx
@@ -298,7 +298,9 @@ const Shop: React.FC<Props> = ({
             </div>
 
             <section aria-label="Магазин" className={isDesktopView ? "mt-8" : "mt-6"}>
-              <h2 className={sectionTitleClass}>Магазин</h2>
+              {!isDesktopView && (
+                <h2 className={sectionTitleClass}>Магазин</h2>
+              )}
 
               {shopLoading && (
                 <div className={shopSpinnerClass}>


### PR DESCRIPTION
## Summary
- hide the shop section heading when rendered inside the VK Desktop frame

## Testing
- npm test -- --watchAll=false (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68df9f18c6f8832ab9885c6649c5f6a5