### PR TITLE
Remove VK Desktop shop frame header

### DIFF
--- a/src/Shop.tsx
+++ b/src/Shop.tsx
@@ -298,7 +298,9 @@ const Shop: React.FC<Props> = ({
             </div>
 
             <section aria-label="Магазин" className={isDesktopView ? "mt-8" : "mt-6"}>
-              <h2 className={sectionTitleClass}>Магазин</h2>
+              {!isDesktopView && (
+                <h2 className={sectionTitleClass}>Магазин</h2>
+              )}
 
               {shopLoading && (
                 <div className={shopSpinnerClass}>
@@ -413,11 +415,7 @@ const Shop: React.FC<Props> = ({
   };
 
   if (isDesktopView) {
-    return (
-      <VKDesktopFrame title="Магазин" accent="amber">
-        {renderContent()}
-      </VKDesktopFrame>
-    );
+    return <VKDesktopFrame accent="amber">{renderContent()}</VKDesktopFrame>;
   }
 
   return <div className="p-6">{renderContent()}</div>;


### PR DESCRIPTION
## Summary
- stop passing the shop title into the VK Desktop frame so the desktop layout no longer renders the header banner

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df9f18c6f8832ab9885c6649c5f6a5